### PR TITLE
修复一些直播源无法在Tivimate中播放

### DIFF
--- a/Adult.m3u
+++ b/Adult.m3u
@@ -22,73 +22,73 @@ https://j9.avstatic.com/contents/videos/28000/28822/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",玩偶•橘子猫「合作集」
 https://v4.cvhlscdn.com/20230426/guDLBTn8/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",真心话大冒险「情人节特辑」
-https://v4.cvhlscdn.com/20230311/soCDcqfB/hls/index.m3u8?
+https://v4.cvhlscdn.com/20230311/soCDcqfB/hls/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",新季里的某一天「新年开作2023」
-https://v4.cvhlscdn.com/20230216/iw7LeEbx/hls/index.m3u8?
+https://v4.cvhlscdn.com/20230216/iw7LeEbx/hls/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",情侣游戏 零
 https://v4.cvhlscdn.com/20221204/dDLVEjQM/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",情侣游戏 壹
 https://v4.cvhlscdn.com/20230129/zqeHgwbd/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",一日女友的漂亮姐姐 上
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ph/gr/7v/78/af7b145ecae246b2ac79cecb6f47f6ad.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ph/gr/7v/78/af7b145ecae246b2ac79cecb6f47f6ad.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",一日女友的漂亮姐姐 中
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/j3/i6/yf/uj/4c59de88250d4dce94d5e5260a48468a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/j3/i6/yf/uj/4c59de88250d4dce94d5e5260a48468a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",一日女友的漂亮姐姐 下
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/k6/r5/4l/88/60aac9f4edee40078853a86817ead1ff.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/k6/r5/4l/88/60aac9f4edee40078853a86817ead1ff.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",一日女友的漂亮姐姐 番外  ASMR姐姐的梦境
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/74/oh/ov/ky/be6214b2998f4f33a65d8e879fc77c8e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/74/oh/ov/ky/be6214b2998f4f33a65d8e879fc77c8e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",一日女友的漂亮姐姐 番外篇二 热恋海岸线
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/yu/mt/0k/df/68768a0f7843400c91a65843e069f9fa.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/yu/mt/0k/df/68768a0f7843400c91a65843e069f9fa.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",森林00-她的妄想
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8c/sf/lc/5c/34774a9c12b649619c8f4049759c35bf.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8c/sf/lc/5c/34774a9c12b649619c8f4049759c35bf.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",森林01-相遇
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/q9/cf/me/5p/453774d191ce481d9714925f1fba72bc.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/q9/cf/me/5p/453774d191ce481d9714925f1fba72bc.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",森林02-欺骗
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jm/jr/pg/bh/03dd6e239b5c40ceb3b156344a64b372.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jm/jr/pg/bh/03dd6e239b5c40ceb3b156344a64b372.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",森林03-碎裂
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/si/p3/76/69/ff14c7c54f1143ddaacac8810fdb8e90.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/si/p3/76/69/ff14c7c54f1143ddaacac8810fdb8e90.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",森林04-吴可玖瑶(终)
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qy/fi/ih/p7/dd522f6b3bd64097ba0e4350b9e65e1c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qy/fi/ih/p7/dd522f6b3bd64097ba0e4350b9e65e1c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",夏日回忆1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/b3/tk/kw/y1/4cbb66dfcd884546994ebf0fe557635d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/b3/tk/kw/y1/4cbb66dfcd884546994ebf0fe557635d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",夏日回忆2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8v/45/pi/sf/049e460a47e94faabd6e1b7bda0bb6ba.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8v/45/pi/sf/049e460a47e94faabd6e1b7bda0bb6ba.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",夏日回忆3
 https://v4.cvhlscdn.com/20220102/MWEjUEmA/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",海岛生活1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/f3/op/3a/ja/1bfcd36a631e400f9e673a66fbfb7385.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/f3/op/3a/ja/1bfcd36a631e400f9e673a66fbfb7385.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",海岛生活2
 https://v4.cvhlscdn.com/20220807/thM7wsId/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",海岛生活3
 https://v4.cvhlscdn.com/20220823/sFbrS6lG/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",甜美游戏陪玩1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uu/7f/bg/b5/28ed051cdec84ccc98cb9a8a72b2a1aa.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uu/7f/bg/b5/28ed051cdec84ccc98cb9a8a72b2a1aa.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",甜美游戏陪玩2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ex/yn/el/3k/09f83fc673314e1c8fda7139737b4f1a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ex/yn/el/3k/09f83fc673314e1c8fda7139737b4f1a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",甜美游戏陪玩3
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/us/6e/s5/8s/72622236ce244252b9726a3530820f28.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/us/6e/s5/8s/72622236ce244252b9726a3530820f28.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",甜美游戏陪玩4
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yf/kq/h5/62/0edc074baab140e1976e12e1099d70d2.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yf/kq/h5/62/0edc074baab140e1976e12e1099d70d2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",晨钟/暮鼓1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qu/rw/07/7u/3f708cc50f054574b72074d960e31609.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qu/rw/07/7u/3f708cc50f054574b72074d960e31609.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",晨钟/暮鼓2
 https://v4.cvhlscdn.com/20220713/pU4sKd7M/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",青蛇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2v/hl/ll/f0/ec17339c89b348b3a3d66edfeb412b24.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2v/hl/ll/f0/ec17339c89b348b3a3d66edfeb412b24.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",蛇喰梦子的陨落
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/qy/yi/94/89/6dc3c8cb9112436682a5af22588f52a0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/qy/yi/94/89/6dc3c8cb9112436682a5af22588f52a0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",情人节特辑
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/gj/v2/mf/a8/77534e95584448e4a62d3205b260e398.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/gj/v2/mf/a8/77534e95584448e4a62d3205b260e398.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",动漫《缘之空》穹妹
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/11/pw/5m/9o/7767714a57434242a353b23d4a3ef841.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/11/pw/5m/9o/7767714a57434242a353b23d4a3ef841.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",纯性爱练习手册
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cg/ph/pg/jv/e48dfc4be58e4e6dab20065a71925079.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cg/ph/pg/jv/e48dfc4be58e4e6dab20065a71925079.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",按摩师
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8t/0r/9y/ho/5819556d96384d6f8b0db87e873e440a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8t/0r/9y/ho/5819556d96384d6f8b0db87e873e440a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",兔女郎
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/u2/ni/d4/7e/8b76511993614e2c84bcf6a7e2ead496.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/u2/ni/d4/7e/8b76511993614e2c84bcf6a7e2ead496.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",独自练习1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/i6/ic/gf/sz/5aae7ba090374eb89fa4cf650d8a8c27.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/i6/ic/gf/sz/5aae7ba090374eb89fa4cf650d8a8c27.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",独自练习2
 https://v4.cvhlscdn.com/20220623/M51SpQDH/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-六月[1]
@@ -114,782 +114,782 @@ https://v4.cvhlscdn.com/20221221/esuqsIX3/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-万圣节•特写
 https://v4.cvhlscdn.com/20221130/2afJFH36/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-白丝诱惑
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/pc/pl/12/8b/e42a460570f24b01a74d96680dda0786.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/pc/pl/12/8b/e42a460570f24b01a74d96680dda0786.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-连体衣
 https://v4.cvhlscdn.com/20220820/UJzhqJ5w/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-美臀福利
 https://v4.cvhlscdn.com/20221105/J0hLzAts/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-碎花内衣
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/69/jb/bi/fw/20126e7e0a12462b918d967cf87b8bda.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/69/jb/bi/fw/20126e7e0a12462b918d967cf87b8bda.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-情趣女仆
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/am/jr/eo/yr/895402a7622e48228f71fb2b874345d6.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/am/jr/eo/yr/895402a7622e48228f71fb2b874345d6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-粉嫩黑丝
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/hr/mw/v7/cj/91fbc7eb82a449148ab6a0b58d5b9268.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/hr/mw/v7/cj/91fbc7eb82a449148ab6a0b58d5b9268.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-久违中出
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/a4/f2/bf/ak/6efd2825848243879a24c6eaac25c86f.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/a4/f2/bf/ak/6efd2825848243879a24c6eaac25c86f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-白丝JK
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/pp/hh/cs/je/277847fb29e14f0c9925baf67fea96f0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/pp/hh/cs/je/277847fb29e14f0c9925baf67fea96f0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-超紧裙子
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/h3/pc/tc/pu/17ade76bc5b64b7dbe4849cea2d79ae4.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/h3/pc/tc/pu/17ade76bc5b64b7dbe4849cea2d79ae4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-黑丝JK
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ca/jp/jl/up/b792f63ce5eb40b591b2f99d0cf975bd.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ca/jp/jl/up/b792f63ce5eb40b591b2f99d0cf975bd.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-玩具足交
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kv/y2/py/nv/edce4ada13884f1591c8af5e1063a192.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kv/y2/py/nv/edce4ada13884f1591c8af5e1063a192.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-激情纯爱
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/ep/gu/9m/4l/fbcbd17845504371b6e95ff3b2086a45.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/ep/gu/9m/4l/fbcbd17845504371b6e95ff3b2086a45.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-粉嫩白丝
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/do/4z/d7/k4/f51157f041264e4cb4490dd344803668.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/do/4z/d7/k4/f51157f041264e4cb4490dd344803668.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-懒惰
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ff/4b/yn/rh/b181c716e35f48d1aee0063c5f714be1.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ff/4b/yn/rh/b181c716e35f48d1aee0063c5f714be1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-快乐时光
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ye/rp/r8/bb/7c2fa3a7fca04875a56f3eb710a41224.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ye/rp/r8/bb/7c2fa3a7fca04875a56f3eb710a41224.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-「流」
 https://v4.cvhlscdn.com/20211103/fF6r1loI/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-「2022」
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jv/t1/9o/ji/6c4a0c8b190944bc8dee75fc8e37cc67.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jv/t1/9o/ji/6c4a0c8b190944bc8dee75fc8e37cc67.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",短片-「晨」
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/eo/hw/ag/q1/1105642eb79f45f580c473c9fcb64725.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/eo/hw/ag/q1/1105642eb79f45f580c473c9fcb64725.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",花絮-公共场合
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lu/2b/qx/84/13f8f69e45ff4c85ac114a3df7b1ca9e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lu/2b/qx/84/13f8f69e45ff4c85ac114a3df7b1ca9e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",花絮-幕后花絮•1
 https://v4.cvhlscdn.com/20210918/pg4sWQLe/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="玩偶",花絮-幕后花絮•2
 https://v4.cvhlscdn.com/20221105/0NXbWItw/hls/index.m3u8
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",3D肉蒲团
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qh/yf/wo/e9/cc0187d5f4064e60a8d9507ccdbeaf4a.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qh/yf/wo/e9/cc0187d5f4064e60a8d9507ccdbeaf4a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",一路向西
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/fd/ea/eu/2q/7bd22841f6dd4b768ab5d1e38419bf4b.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/fd/ea/eu/2q/7bd22841f6dd4b768ab5d1e38419bf4b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",鸭王
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/fo/4n/1u/xg/304cc44af0334b39b0989c4e224ec966.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/fo/4n/1u/xg/304cc44af0334b39b0989c4e224ec966.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",爱很烂
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/vf/c1/xy/je/9c181c81984e456a9ade1fa8c0021770.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/vf/c1/xy/je/9c181c81984e456a9ade1fa8c0021770.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",金瓶梅2008
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/c0/xf/gg/0f/8a292587e31a4a3eaa0181399728341b.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/c0/xf/gg/0f/8a292587e31a4a3eaa0181399728341b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",金瓶梅 2009
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/5r/f0/91/pt/657f7457792046f0b26296e7ab8dc54c.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/5r/f0/91/pt/657f7457792046f0b26296e7ab8dc54c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",新金瓶梅-1「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/9n/om/ey/m3/5818f7a375364105b91f73443101fbc8.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/9n/om/ey/m3/5818f7a375364105b91f73443101fbc8.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",新金瓶梅-2「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/st/og/8r/id/95b2f1ca83914736bf80677f168c8a9d.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/st/og/8r/id/95b2f1ca83914736bf80677f168c8a9d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",新金瓶梅-3「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/j1/je/h3/ny/bd613c602d5a4e9a9e4666ec25899422.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/j1/je/h3/ny/bd613c602d5a4e9a9e4666ec25899422.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",新金瓶梅-4「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ys/ct/jj/2v/4d20dc3e83a54dbbbd0882d8156f7a5e.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ys/ct/jj/2v/4d20dc3e83a54dbbbd0882d8156f7a5e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",新金瓶梅-5「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/st/fa/rg/ao/1c8293e0715c465f8b859b0379ce6155.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/st/fa/rg/ao/1c8293e0715c465f8b859b0379ce6155.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",赤裸羔羊「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/a9/bu/cc/ke/aa740a3be9a145d4985d3a3add1f8424.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/a9/bu/cc/ke/aa740a3be9a145d4985d3a3add1f8424.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",赤裸狂奔「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/sp/ml/jz/ho/3e495ccc222f46399b914db50529227a.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/sp/ml/jz/ho/3e495ccc222f46399b914db50529227a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",玉蒲团2玉女心经「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/m9/oz/g8/5z/256b9ee37b5d407c8df9a8f27a9bc5fc.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/m9/oz/g8/5z/256b9ee37b5d407c8df9a8f27a9bc5fc.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",情难自制「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/p9/5v/9t/j0/e18f0c1590a940eca9443e6a2ffdee3b.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/p9/5v/9t/j0/e18f0c1590a940eca9443e6a2ffdee3b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",勾魂噩梦「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/de/8i/j5/cd/92b61d3b80514007a60da1c9a4210189.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/de/8i/j5/cd/92b61d3b80514007a60da1c9a4210189.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",聊斋艳谭3：灯草和尚「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/4p/48/z1/q0/851e1443df22425687209bd894113842.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/4p/48/z1/q0/851e1443df22425687209bd894113842.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",聊斋艳谭续集：五神通「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/em/nl/x2/h0/1fabfbc638264c6c8a73a03666df2d2a.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/em/nl/x2/h0/1fabfbc638264c6c8a73a03666df2d2a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",人皮高跟鞋「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/8w/um/l5/ab/49e4bc7b21274d96938e216afa0b5029.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/8w/um/l5/ab/49e4bc7b21274d96938e216afa0b5029.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",唐朝豪放女「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/t1/9l/x5/vh/86bd1e2835c24666b36709be8d2583e2.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/t1/9l/x5/vh/86bd1e2835c24666b36709be8d2583e2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",艳降勾魂「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/bj/z0/q7/by/5b49b5ff15484a5aab4a3d0d55d608ec.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/bj/z0/q7/by/5b49b5ff15484a5aab4a3d0d55d608ec.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",摩登龙争虎斗「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/4d/4q/84/b9/edd66c1ce5424c5d85c28c329b083b73.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/4d/4q/84/b9/edd66c1ce5424c5d85c28c329b083b73.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",盲女72小时「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/kr/p9/qh/u6/1de1e1489f964278b570ba32b8ba5f4e.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/kr/p9/qh/u6/1de1e1489f964278b570ba32b8ba5f4e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",食色性也「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ow/34/6t/45/5625c6528b5742eaaabdaa34b7fbd017.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ow/34/6t/45/5625c6528b5742eaaabdaa34b7fbd017.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",淫狼心「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/yi/bn/ec/gz/23ff00f09d9c460f9c91a451617e8120.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/yi/bn/ec/gz/23ff00f09d9c460f9c91a451617e8120.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",五月樱唇「修复」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/1q/92/2c/l2/dcb00c7faa4d4a1cab77f8cef6cd3f14.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/1q/92/2c/l2/dcb00c7faa4d4a1cab77f8cef6cd3f14.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",色戒「钟丽缇」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/mi/9y/lp/a0/7c25ca58b5134db8b02029878c975025.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/mi/9y/lp/a0/7c25ca58b5134db8b02029878c975025.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",色戒「汤唯」
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ns/dt/4a/po/2db3e0f27bc74b9b84cf36b539a90081.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ns/dt/4a/po/2db3e0f27bc74b9b84cf36b539a90081.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",灭门惨案之孽杀
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/ph/ar/xo/yj/58d41640a9e6447db67ad3e161c28e66.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/ph/ar/xo/yj/58d41640a9e6447db67ad3e161c28e66.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",灭门惨案2:借种
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/1f/wk/cl/w4/86ad88a49fcf42778d5fb1522845c8a7.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/1f/wk/cl/w4/86ad88a49fcf42778d5fb1522845c8a7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",八仙饭店之人肉叉烧包
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/a7/li/3d/wm/28ff3b4bb94846c68565f7cccb45b84b.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/a7/li/3d/wm/28ff3b4bb94846c68565f7cccb45b84b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",金瓶风月
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/bv/na/64/js/bc13bb11a2734309a97c51e8018062a0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/bv/na/64/js/bc13bb11a2734309a97c51e8018062a0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",聊斋艳谭
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/hj/gn/9q/pf/328249e08ba04574b40ce799e997d7f7.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/hj/gn/9q/pf/328249e08ba04574b40ce799e997d7f7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",聊斋惊艳
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/i2/dv/us/uz/22ea327b9ed8494b86d4c93b3efbbb90.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/i2/dv/us/uz/22ea327b9ed8494b86d4c93b3efbbb90.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",聊斋金瓶梅
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/y4/my/fk/ri/6195420d42f54abe8c997cb3859aa8a5.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/y4/my/fk/ri/6195420d42f54abe8c997cb3859aa8a5.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",聊斋花弄月
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ay/u7/zm/9e/8d8af725105d45deae2dde3912289813.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ay/u7/zm/9e/8d8af725105d45deae2dde3912289813.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",情不自禁
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/9w/hm/1l/3e/ab8f485579fa4412a33b66ffbcf1b560.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/9w/hm/1l/3e/ab8f485579fa4412a33b66ffbcf1b560.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",私人会所
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/3u/km/tb/8f/779be310075f4d31ac351260ebaf9c22.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/3u/km/tb/8f/779be310075f4d31ac351260ebaf9c22.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",惊变
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/01/gh/8c/mu/6f08b2047a4c43fb80a6b84b4a210c8e.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/01/gh/8c/mu/6f08b2047a4c43fb80a6b84b4a210c8e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",欲海花
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/mp/xu/5a/2z/3b0bf943125c4d8d935354e42aece2f7.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/mp/xu/5a/2z/3b0bf943125c4d8d935354e42aece2f7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",艳遇
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ue/ex/zi/lr/581c6123fb6e4a46a3c3741e0dfe7099.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ue/ex/zi/lr/581c6123fb6e4a46a3c3741e0dfe7099.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",青春梦里人
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/89/h2/44/ty/e9f3d66259244784ae77a5dc9f009736.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/89/h2/44/ty/e9f3d66259244784ae77a5dc9f009736.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",不覊的心
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/3u/zp/4s/rh/b3acaabe7e0b4c148b3571da6fc9f41c.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/3u/zp/4s/rh/b3acaabe7e0b4c148b3571da6fc9f41c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",色情男女
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qn/j9/i6/64/b6c190ec698341529f7b7142ec3b0c88.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qn/j9/i6/64/b6c190ec698341529f7b7142ec3b0c88.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",少女情怀总是诗
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/wo/1n/sn/33/fbad81446c7c4a35923690640c20a38d.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/wo/1n/sn/33/fbad81446c7c4a35923690640c20a38d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",蜜桃来偷欢
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/oh/ja/jq/y7/a11df34ee2574fbfbe46ce724fa56f17.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/oh/ja/jq/y7/a11df34ee2574fbfbe46ce724fa56f17.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",灵幻新娘
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/13/8j/ol/z6/947bcb5ad38f4a5eab132da3a94cc85f.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/13/8j/ol/z6/947bcb5ad38f4a5eab132da3a94cc85f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",摧花神龙教
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/rt/ix/j5/50/5a8f75848e7f4fb68539c8032a42800a.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/rt/ix/j5/50/5a8f75848e7f4fb68539c8032a42800a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",哎吔女朋友
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/j3/y1/ky/tw/d7e7162e7e474253bf7fcd0c5eddd047.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/j3/y1/ky/tw/d7e7162e7e474253bf7fcd0c5eddd047.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",不文小丈夫之银座嬉春
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/7n/s6/95/b4/64b1be8333004ba5ae30665390893889.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/7n/s6/95/b4/64b1be8333004ba5ae30665390893889.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",野性任务
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/nt/95/ca/ig/f518cd1e815047fb9bbcc432d78afdc8.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/nt/95/ca/ig/f518cd1e815047fb9bbcc432d78afdc8.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="香港",花街狂奔
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/zu/ty/p1/jk/3259f3f5abad4eb59e6eb0d81e9c14f1.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/zu/ty/p1/jk/3259f3f5abad4eb59e6eb0d81e9c14f1.m3u8?love=freedom
 
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生", 美乳少女荒野求精/户外特辑-岩洞荒野/TZ-114
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/r0/rx/35/uo/b4a1346429e04d929c97b9843da36c91.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/r0/rx/35/uo/b4a1346429e04d929c97b9843da36c91.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",我的百变女友/凌波丽/TZ-113
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/iv/pt/6q/vd/6476816d621042c783018eb44886efe0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/iv/pt/6q/vd/6476816d621042c783018eb44886efe0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",兔子按摩院 EP6/国宝级K杯巨乳/TZ-112
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/19/ru/fs/dx/f849078185e0403290aef65b774391fd.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/19/ru/fs/dx/f849078185e0403290aef65b774391fd.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",日式精油按摩体验/萌音少女上门服务/Tz-111
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/jz/5y/ta/oq/ec3c07ed6255412da15fb392e39b05ac.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/jz/5y/ta/oq/ec3c07ed6255412da15fb392e39b05ac.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",父亲节迷姦巨乳女儿-给爸爸最好的礼物/TZ-110
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qa/pt/5g/yq/4c005b1271be4f93a9191cc691ba4ac5.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qa/pt/5g/yq/4c005b1271be4f93a9191cc691ba4ac5.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",輪姦女搜查官(下篇)男上司叛變与肉便器罪犯/TZ-109-02
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/8b/yc/5e/bb/1ba6e65497ef4c198af780d89c26e1a2.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/8b/yc/5e/bb/1ba6e65497ef4c198af780d89c26e1a2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",輪姦女搜查官(上篇)掉入陷阱的肉便器/TZ-109-01
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/p0/pz/uv/vt/7cf9aea7d0574bb9aace6088ea1735cb.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/p0/pz/uv/vt/7cf9aea7d0574bb9aace6088ea1735cb.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",癡女與植物人丈夫/TZ-108
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/3b/zs/w3/fk/5bd96f09700f48de8458ea6227533a10.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/3b/zs/w3/fk/5bd96f09700f48de8458ea6227533a10.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",痴汊尾行-餐廳露出強姦/TZ-107
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7o/ry/4q/lz/15ef36cf640a48c9bbb81706376f16d7.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7o/ry/4q/lz/15ef36cf640a48c9bbb81706376f16d7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",母親節特别篇-給儿子的禮物/TZ-106
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ee/8r/8k/la/7087fb756fad43fea40d8a28394cde3b.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ee/8r/8k/la/7087fb756fad43fea40d8a28394cde3b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",島国特色泡泡浴 EP4/k杯神乳美体享受/TZ-105
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1c/w5/ej/yi/441fe16f7d4746ccaaa68a29bd3c9083.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1c/w5/ej/yi/441fe16f7d4746ccaaa68a29bd3c9083.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",兔孑按摩院EP5/巨乳技师贴身服务/TZ-104
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/os/xi/o7/oq/a205452df85747f7b21f522038fc3bea.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/os/xi/o7/oq/a205452df85747f7b21f522038fc3bea.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",酒醉姐姐撿回家EP4/寂寞OL深夜談心/TZ-103
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ak/us/a0/da/5415e2423e38423c8e1cf9bdf5322a95.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ak/us/a0/da/5415e2423e38423c8e1cf9bdf5322a95.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP21/DAD-005
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/dx/li/rm/6c/4d0d807b45394e898839f5f404a8e664.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/dx/li/rm/6c/4d0d807b45394e898839f5f404a8e664.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP20/DAD-004
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/vy/xd/0x/hs/161a919cbecc4650a00b889c1b19f31c.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/vy/xd/0x/hs/161a919cbecc4650a00b889c1b19f31c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP28/DAD-012
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/8u/57/f2/xb/7283cb4a1cd14494a318dcbda3c310fa.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/8u/57/f2/xb/7283cb4a1cd14494a318dcbda3c310fa.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP29/DAD-013
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/83/ss/c7/iv/16bda84fe84e447c986954e3730a2cab.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/83/ss/c7/iv/16bda84fe84e447c986954e3730a2cab.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP27/DAD-011
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/in/m5/55/hj/3d3912ff88194bf99f0cc3f9a159a3f2.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/in/m5/55/hj/3d3912ff88194bf99f0cc3f9a159a3f2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP26/DAD-010
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/20/xc/zz/lo/4be8be5076a54f8a9ce761967d117e8d.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/20/xc/zz/lo/4be8be5076a54f8a9ce761967d117e8d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP25/DAD-009
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/ws/8c/2t/7q/38b09c5882a541c0b623f60027bdab1c.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/v2/av/ws/8c/2t/7q/38b09c5882a541c0b623f60027bdab1c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP24/DAD-008
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/bf/ho/vd/0y/43725e839b0342a3bfbeef9c3c8e31a7.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/bf/ho/vd/0y/43725e839b0342a3bfbeef9c3c8e31a7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP23/DAD-007
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/42/cg/db/gk/4caba03d831d4539bec565fa90fbee81.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/42/cg/db/gk/4caba03d831d4539bec565fa90fbee81.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP22/DAD-006
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/qe/o7/w0/c9/056288402deb4f08a53c2d4e5e2ae3b1.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/qe/o7/w0/c9/056288402deb4f08a53c2d4e5e2ae3b1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP19/DAD-003
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/dz/1w/3w/hu/91094f0fa07f4df0b7b5b5b839193e5f.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/dz/1w/3w/hu/91094f0fa07f4df0b7b5b5b839193e5f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP18/DAD-002
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/s0/31/33/ip/4b21066041b34a8bad1c69f9ebb32156.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/s0/31/33/ip/4b21066041b34a8bad1c69f9ebb32156.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP17/DAD-001
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/u2/7o/x6/8o/cace3b68e32e4164b66bb2df666a2583.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/u2/7o/x6/8o/cace3b68e32e4164b66bb2df666a2583.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",淫亂4P忘年會/無休止的輪姦/TZ-100
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yw/yq/05/bk/7e557f0ceb77437d99c0c87be3631f9c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yw/yq/05/bk/7e557f0ceb77437d99c0c87be3631f9c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",春之夜/TZ-099
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/xb/1b/9w/p5/0018892a5670462d8c17447b26515494.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/xb/1b/9w/p5/0018892a5670462d8c17447b26515494.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",與人妻的一天/TZ-098
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/r8/x5/ab/i5/26f46dc22c124b3287b504f88444e514.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/r8/x5/ab/i5/26f46dc22c124b3287b504f88444e514.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",癡女社長/TZ-097
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/25/mz/yw/xj/96b4e98d9bd44dbcb72ab0dfdc2f1d5b.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/25/mz/yw/xj/96b4e98d9bd44dbcb72ab0dfdc2f1d5b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",父債女償/TZ-096
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/nw/tm/rw/sr/287177d656a9415fba54d59e58c92184.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/nw/tm/rw/sr/287177d656a9415fba54d59e58c92184.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",兔子按摩院 EP3/極品騷女深度按摩/TZ-095
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1v/lj/1t/ro/e969eb2bb9234f46be5497b569c61200.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1v/lj/1t/ro/e969eb2bb9234f46be5497b569c61200.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爆肏女主播/TZ-094
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/w3/5n/9u/mr/6b2a4b262fae44999841d10706bc9d71.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/w3/5n/9u/mr/6b2a4b262fae44999841d10706bc9d71.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",淫女好呻吟 第二期 性愛篇/TZ-093-AV2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/rv/sa/pc/2z/0d8632fc79ee4d8bac60cf316a79118f.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/rv/sa/pc/2z/0d8632fc79ee4d8bac60cf316a79118f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",淫女好呻吟 第二期 節目篇/TZ-093-EP2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/c3/mn/mp/un/c5cf3b068c514d73bcd9df2243986e3c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/c3/mn/mp/un/c5cf3b068c514d73bcd9df2243986e3c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",淫女好呻吟 第一期 性愛篇/TZ-093-AV1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/b9/je/ez/p2/d4b07611a8744f5b8fffc3f38e2af6a8.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/b9/je/ez/p2/d4b07611a8744f5b8fffc3f38e2af6a8.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",淫女好呻吟 第一期 節目篇/TZ-093-EP1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/94/0w/5c/f9/cba11457d069448fbc861de4b0c0f5a1.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/94/0w/5c/f9/cba11457d069448fbc861de4b0c0f5a1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",大學校花性愛實錄/TZ-092
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2q/yn/b0/r8/a7895fdf972148bca490e571bdd72940.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2q/yn/b0/r8/a7895fdf972148bca490e571bdd72940.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",島国特色泡泡浴 EP3/TZ-091
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/4j/vj/x4/1x/4d8bb6adb18c4dae8061be45ab1de59c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/4j/vj/x4/1x/4d8bb6adb18c4dae8061be45ab1de59c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",兔子按摩院 EP1/沉溺於快感的人妻/TZ-090
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/me/l7/q5/dk/b727859c3d844d5581c4b340fd5397b1.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/me/l7/q5/dk/b727859c3d844d5581c4b340fd5397b1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP16/巨乳美女的性感肉體/TZ-089
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/3p/po/jm/xq/494112c70f5f40209b64b599178204a9.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/3p/po/jm/xq/494112c70f5f40209b64b599178204a9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",背德妻「あなた、許して...」EP1/TZ-088
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/1p/sc/8y/9r/830e747b54e4427f89a17d11e8d5eddf.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/1p/sc/8y/9r/830e747b54e4427f89a17d11e8d5eddf.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",大板閨蜜 聖誕雙飛/TZ-087
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/z0/32/4r/fl/378a7766f1a4432dab27847cb6ab2f78.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/z0/32/4r/fl/378a7766f1a4432dab27847cb6ab2f78.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP15/巨乳少女寂寞難耐/TZ-086
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/16/r1/px/xi/508493f3309e4c8ab2d2c32e54e34ce2.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/16/r1/px/xi/508493f3309e4c8ab2d2c32e54e34ce2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",前女友訂婚禮物/TZ-085
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/lw/nf/ak/cj/b16f03c4ba814dd6a365151ab4f03031.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/lw/nf/ak/cj/b16f03c4ba814dd6a365151ab4f03031.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",我的美国妹妹/TZ-084
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/re/kc/ov/fp/723d96b3f62746f0b3558c0d532f2b89.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/re/kc/ov/fp/723d96b3f62746f0b3558c0d532f2b89.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",日本高中生上門援交/TZ-083
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/y9/59/a0/bs/a62b1101041b48be89ee2582ef60a323.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/y9/59/a0/bs/a62b1101041b48be89ee2582ef60a323.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",酒醉姐姐撿回家EP3/肆意玩弄巨乳OL/TZ-082
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/qt/59/n7/5n/3f42b8fc68a84cf9979492492e752a7e.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/qt/59/n7/5n/3f42b8fc68a84cf9979492492e752a7e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",盗摂-情色按摩院/TZ-081
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/4g/my/1k/rq/d34f4d5d52d44ff2a6dc839fc568471b.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/4g/my/1k/rq/d34f4d5d52d44ff2a6dc839fc568471b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP14/白虎妹妹巨乳細腰/TZ-080
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ws/yv/ds/4k/351d1e92f54b48ddb9b7a2960f398b86.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ws/yv/ds/4k/351d1e92f54b48ddb9b7a2960f398b86.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",黑絲空姐貼身服務/TZ-079
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9n/bd/16/46/3ab42a6a4c68462f8b57a702d969df9c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9n/bd/16/46/3ab42a6a4c68462f8b57a702d969df9c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",機械人女友-下/TZ-078-2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ij/em/qa/ha/1ae08d93f19c4b2ea53522c84cd7bb05.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ij/em/qa/ha/1ae08d93f19c4b2ea53522c84cd7bb05.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",機械人女友-上/TZ-078-1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/iq/k0/jx/t1/9e2a3d3391e84203bb2389b1ac3a0555.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/iq/k0/jx/t1/9e2a3d3391e84203bb2389b1ac3a0555.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",友人の妹(性幻想)/TZ-077
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/c6/09/l0/oo/4a0732841cd6407eac26df460ab46fc5.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/c6/09/l0/oo/4a0732841cd6407eac26df460ab46fc5.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",街邊搭訕兼職女大學生/TZ-076
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ya/uk/rc/el/d7a6e09cebdb492db1043780ab0e8fe4.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ya/uk/rc/el/d7a6e09cebdb492db1043780ab0e8fe4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中秋團圓人姦情(下)/TZ-075-2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/r8/nw/l1/sh/2a542a6ddfec4b7baa8e5600299108f5.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/r8/nw/l1/sh/2a542a6ddfec4b7baa8e5600299108f5.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中秋團圓人姦情(上)/TZ-075-1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/wv/9s/dd/pf/c1b926861a254a1390b099b6a26edb54.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/wv/9s/dd/pf/c1b926861a254a1390b099b6a26edb54.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",恩從我師 從性開始/TZ-074
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/s1/c1/ek/yx/83fd0435598343d68b975ecd4592c5c3.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/s1/c1/ek/yx/83fd0435598343d68b975ecd4592c5c3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",日式泡泡浴/TZ-073
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/94/jn/40/pi/226f2c7d279a46eaaac3d4532872d6ee.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/94/jn/40/pi/226f2c7d279a46eaaac3d4532872d6ee.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP13/TZ-072
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ej/og/8r/y5/b0e4f0a1c31a4518938cbea4ac73ae6d.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ej/og/8r/y5/b0e4f0a1c31a4518938cbea4ac73ae6d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",女優面試 現場實錄/TZ-071
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/j1/hh/kn/fy/80f7288e70ab4ca788853f6984d44a8b.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/j1/hh/kn/fy/80f7288e70ab4ca788853f6984d44a8b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第四期 性愛篇/TZ-070-AV4
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yt/v9/gk/3r/45a0d97ab1284c529a4e1b80040d09a5.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yt/v9/gk/3r/45a0d97ab1284c529a4e1b80040d09a5.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第四期 節目篇/TZ-070-EP4
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/sc/hi/43/xh/0be73dbf26f5431bb0726fece0af0350.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/sc/hi/43/xh/0be73dbf26f5431bb0726fece0af0350.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第三期 性愛篇/TZ-070-AV3
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7a/ih/ys/7a/e5198557259f478bbd3c43bfe2708601.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7a/ih/ys/7a/e5198557259f478bbd3c43bfe2708601.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第三期 節目篇/TZ-070-EP3
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lh/g8/5o/3f/3a2ee15d17744053888a65cc3d340f9d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lh/g8/5o/3f/3a2ee15d17744053888a65cc3d340f9d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第二期 性愛篇/TZ-070-AV2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/oh/px/id/x0/10853c3fd88c4b0285e0945b87eb3e8e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/oh/px/id/x0/10853c3fd88c4b0285e0945b87eb3e8e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第二期 節目篇/TZ-070-EP2
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/sy/t0/lr/xs/70177086976c4b01b89746fc473a3cc4.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/sy/t0/lr/xs/70177086976c4b01b89746fc473a3cc4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第一期 性愛篇/TZ-070-AV1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/vo/8z/tk/p1/e9f8bfafe0764b00870a72cbd8e3ffce.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/vo/8z/tk/p1/e9f8bfafe0764b00870a72cbd8e3ffce.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",色情運動會 第一期 節目篇/TZ-070-EP1
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/wu/a3/3m/4r/3f3487fdab054eceb8fb68411f119b46.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/wu/a3/3m/4r/3f3487fdab054eceb8fb68411f119b46.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",養育之恩以身相報/TZ-069
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/2d/cm/jx/j0/a8d6a1a1e43d489f91332d7db666d0bf.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/2d/cm/jx/j0/a8d6a1a1e43d489f91332d7db666d0bf.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",濕身情人夜/TZ-068
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/9v/re/xw/ea/86f96fd5c92d4c67bdddb4db69ea7714.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/9v/re/xw/ea/86f96fd5c92d4c67bdddb4db69ea7714.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP12/TZ-067
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/u2/fn/8f/g0/6d9ebc3e7b5f4ee7848d93a6ad99939d.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/u2/fn/8f/g0/6d9ebc3e7b5f4ee7848d93a6ad99939d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",好友性愛挑戰賽/TZ-066
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/hb/4d/y4/8w/a711a591d422499e82de8b9ffdc70b46.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/hb/4d/y4/8w/a711a591d422499e82de8b9ffdc70b46.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",人妻替夫還債/TZ-065
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2g/qv/k4/9f/e4d9f7817b084f9aa628387bee8be3aa.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2g/qv/k4/9f/e4d9f7817b084f9aa628387bee8be3aa.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",酒醉姐姐撿回家EP2/TZ-064
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ym/w2/ng/in/a421df26f9834c9c85bc8d92608c3ac0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ym/w2/ng/in/a421df26f9834c9c85bc8d92608c3ac0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",炮機初體驗/TZ-063
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/v9/mg/qh/rr/7929e3ace7814b8789062e199a8e46bb.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/v9/mg/qh/rr/7929e3ace7814b8789062e199a8e46bb.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",兩天一夜(後篇)持續侵犯/TZ-062
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cj/4p/r0/tl/bb208ad7f9974129ad00dc2b16449c7d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cj/4p/r0/tl/bb208ad7f9974129ad00dc2b16449c7d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",兩天一夜(前篇)/持續侵犯/TZ-062
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/iu/3f/0p/x1/5bc22071f9a54ac39e960b2cb6e8e9fe.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/iu/3f/0p/x1/5bc22071f9a54ac39e960b2cb6e8e9fe.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",酒店實錄/上門按摩東瀛女/TZ-061
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/o4/c0/ml/cg/c39ef8d4075344f2a01ab26a2ae37a1d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/o4/c0/ml/cg/c39ef8d4075344f2a01ab26a2ae37a1d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",清純妹妹/性愛初體驗/TZ-060
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qu/lb/40/sg/580cda224a7b43259c29db8b13f0a31c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qu/lb/40/sg/580cda224a7b43259c29db8b13f0a31c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足/超敏感痙攣體質/TZ-059
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/e2/tb/o4/rj/192c0d863e0d4e718e7e1a0ab8728063.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/e2/tb/o4/rj/192c0d863e0d4e718e7e1a0ab8728063.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",土下座痴女OL/奉仕謝罪/TZ-058
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/h3/2d/jm/st/70d58888527f4cf8b2bf30c1320b7a4d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/h3/2d/jm/st/70d58888527f4cf8b2bf30c1320b7a4d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足/蘿莉學生妹/TZ-057
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/al/tq/74/9t/72a72c833ddd4656a074f9f14c11e5d0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/al/tq/74/9t/72a72c833ddd4656a074f9f14c11e5d0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",母親節特別企劃/義母亂倫童貞畢業/TZ-056
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/8b/zt/zg/zu/d64bf42ddd294a27ac5ad6748a25a406.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/8b/zt/zg/zu/d64bf42ddd294a27ac5ad6748a25a406.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",秘密女搜査官/淺入失敗拘束·拷問/TZ-055
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/bj/a7/z8/wm/e384eaaa49c245769d69dffbfb3b50d3.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/bj/a7/z8/wm/e384eaaa49c245769d69dffbfb3b50d3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EPg/和服妹妹賞櫻花!/TZ-054
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/rx/58/m1/49/e1fa5433aa9040c0bba4b48f3f0ebde3.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/rx/58/m1/49/e1fa5433aa9040c0bba4b48f3f0ebde3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",泡泡浴/中出G奶美少女/TZ-053
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/pc/l0/pa/uy/d58b39eb91d24a2283d9061c3d620e28.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/pc/l0/pa/uy/d58b39eb91d24a2283d9061c3d620e28.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",雙孑兄弟/3P性愛實錄/TZ-052
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/t2/wg/yx/v2/157cd8354f024d6291b4dc973705e19f.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/t2/wg/yx/v2/157cd8354f024d6291b4dc973705e19f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP8/童顔巨乳G奶學生妹/TZ-051
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/02/36/4q/o6/9c89af44abe84dc9a0afe41d66d9e4a1.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/02/36/4q/o6/9c89af44abe84dc9a0afe41d66d9e4a1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP8/矇眼・手﨧・3P/TZ-050
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/06/cw/l4/rr/b4ed0fb65d0b404b81c18173e7e6f1d2.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/06/cw/l4/rr/b4ed0fb65d0b404b81c18173e7e6f1d2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP7/淫亂未婚妻狂亂抽插/TZ-049
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/af/9s/i6/fd/074bd37134f544728f0fe2b1c45d7115.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/af/9s/i6/fd/074bd37134f544728f0fe2b1c45d7115.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",痴女3P後篇/激情榨精/TZ-048
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/rk/by/d6/wa/1f1d279b4612433084dde5e2f1681f03.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/rk/by/d6/wa/1f1d279b4612433084dde5e2f1681f03.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",痴女3P前篇/雙爆乳夾擊/TZ-047
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ad/k9/ya/k5/351a03d6088a402e829c3cfea91ae0ce.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ad/k9/ya/k5/351a03d6088a402e829c3cfea91ae0ce.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",貓之日特輯/街頭搭訕小淫貓/TZ-046
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/7j/rz/p4/y0/d51d92d6e64e4fc09018099c5d3d65c4.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/7j/rz/p4/y0/d51d92d6e64e4fc09018099c5d3d65c4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP6/炮機雖好不如大屌/TZ-045
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/4q/de/ca/w9/e31dc533f26d4eafb55c2264ab97f3ec.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/4q/de/ca/w9/e31dc533f26d4eafb55c2264ab97f3ec.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP5/意亂情迷性慾爆發/TZ-044
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/od/lp/l3/tx/3de6b515de844cbf8802ed2a0f22f4b4.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/od/lp/l3/tx/3de6b515de844cbf8802ed2a0f22f4b4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",初六賀歲齊拜年!兔子先生 淫過年(後篇)/TZ-043
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/pd/la/at/nn/bb1b58c1ff6d443cbd0a4c1368b1de0a.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/pd/la/at/nn/bb1b58c1ff6d443cbd0a4c1368b1de0a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",初六賀歲齊拜年!兔子先生 淫過年(前篇)/TZ-042
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/jt/fw/iz/40/092d011a37d64e7bb96222f8e0f6dcbb.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/jt/fw/iz/40/092d011a37d64e7bb96222f8e0f6dcbb.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",島國女僕為你服務/奉獻身體滿足主人/TZ-041
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/hv/sl/70/o5/2230e4efda6d4de29f2a39ec39f0e138.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/hv/sl/70/o5/2230e4efda6d4de29f2a39ec39f0e138.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",雙孑兄弟3P性愛實錄 EP4/巨乳少娟瘋狂榨精/TZ-040
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/2v/02/ek/gc/e9232681c7134ddd97abf4c496ca505e.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/2v/02/ek/gc/e9232681c7134ddd97abf4c496ca505e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",當初戀己成人妻/喪失理性反被逆襲/TZ-039
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/rj/te/v6/3k/5ee5de40efd3411fbf05f01f9a3df593.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/rj/te/v6/3k/5ee5de40efd3411fbf05f01f9a3df593.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP4/瘋狂做愛迎新年/TZ-038
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/wf/yd/4d/c2/1217dc94e20f4eb2aa277ffb010bffe6.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/wf/yd/4d/c2/1217dc94e20f4eb2aa277ffb010bffe6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP3/新年溫泉旅行/TZ-037
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/9f/w3/1o/vo/1035ff52cdfa4a279f296ab6b7007cc3.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/9f/w3/1o/vo/1035ff52cdfa4a279f296ab6b7007cc3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP7/聖誕約會主動求愛/TZ-036
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/jw/lt/4u/vx/b574538b6255484d9bb37e356038b180.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/jw/lt/4u/vx/b574538b6255484d9bb37e356038b180.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",酒醉姐姐撿回家 EP1/為所欲為操到天亮/TZ-035
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/6p/zu/z2/u9/bb840ad68f5140658b55fb43aea62b8c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/6p/zu/z2/u9/bb840ad68f5140658b55fb43aea62b8c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP6/清純護士粉紅誘惑/TZ-034
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ej/j6/qr/da/0857b3de7b174c02a0464c067ce61401.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ej/j6/qr/da/0857b3de7b174c02a0464c067ce61401.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP5/飢渴難耐回房就幹/TZ-033
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uy/8y/wu/de/7fc312fd48e04d108985e0eb5bc78882.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uy/8y/wu/de/7fc312fd48e04d108985e0eb5bc78882.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",淫賤女網友/巨乳爆臀的誘惑/TZ-032
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lb/0u/ss/48/b3676d054e694a5ba8b1a935f0f818b9.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lb/0u/ss/48/b3676d054e694a5ba8b1a935f0f818b9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",瑜珈老師上門服務/風騷老師瘋狂榨精/TZ-031
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2s/ca/hy/sc/9de3135f222c440c9d2d724779461c43.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2s/ca/hy/sc/9de3135f222c440c9d2d724779461c43.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",萬聖節緊急企劃/日本金蓮領我回家/TZ-030
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ag/qi/ij/l2/079eca9b44664d84be021c4998bc0400.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ag/qi/ij/l2/079eca9b44664d84be021c4998bc0400.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",雙子兄弟3P性愛實錄 EP3/性愛女王欲求不滿/TZ-029
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kc/bp/y1/26/e1f35c1d02c441c0a4c512bf0c39d87a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kc/bp/y1/26/e1f35c1d02c441c0a4c512bf0c39d87a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",雙子兄弟3P性愛實錄 EP2/淫蕩護士中出狂歡宴/TZ-028
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/1z/lb/84/q6/eeb7712510ea4265bcddea7d289aef23.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/1z/lb/84/q6/eeb7712510ea4265bcddea7d289aef23.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",雙子兄弟3P性愛實錄 EP1/女子高中生3P初體驗/TZ-027
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ua/gm/14/d5/634e93a9167b40abb472ffe71126cab3.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ua/gm/14/d5/634e93a9167b40abb472ffe71126cab3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP4(下)/手銬調教制服遊戲/TZ-026
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/vh/h1/8g/04/08c4c63d5cbd49f7952b98d985b05431.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/vh/h1/8g/04/08c4c63d5cbd49f7952b98d985b05431.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP4(上)/甜蜜約會極致性愛/TZ-025
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/jr/pj/w8/ob/c205daad382b4b7bb0f7432cc33cc1c9.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/jr/pj/w8/ob/c205daad382b4b7bb0f7432cc33cc1c9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP2/快感炸裂四度高潮/TZ-024
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/54/mu/ea/0n/28da584e9aaf4bc391b25d9ea6aac1d9.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/54/mu/ea/0n/28da584e9aaf4bc391b25d9ea6aac1d9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",東京愛慾故事 EP1/巨乳豊臀性愛遊戲/TZ-023
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ia/1o/6f/nb/bd262c72f46a44b1ae3e4ac7b548d00e.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ia/1o/6f/nb/bd262c72f46a44b1ae3e4ac7b548d00e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",情侶性愛挑戰賽 EP2/荒淫豪禮無套內射/TZ-022
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ca/mu/q7/je/eff1b89202dc4a6bb78d096a4956bfa3.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/av/ca/mu/q7/je/eff1b89202dc4a6bb78d096a4956bfa3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",情侶性愛挑戰賽 EP1/忍不住的強取豪奪/TZ-021
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ws/5r/12/ix/4c369deb83764399966289c190daa6c3.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ws/5r/12/ix/4c369deb83764399966289c190daa6c3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",足球寶貝 EP3 AV篇/足球尤物誘惑性愛!/TZ-020
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2d/9r/yp/6y/7c27a048a60949afbbd43d345bf73980.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2d/9r/yp/6y/7c27a048a60949afbbd43d345bf73980.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",足球寶貝 EP3 節目篇/陰道刺激的射門戰!/TZ-020
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2q/uh/kj/it/6276c3bca47d49f1bea69dbe30b6789f.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2q/uh/kj/it/6276c3bca47d49f1bea69dbe30b6789f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",足球寶貝 EP2 AV篇/下腹高潮的女女交歡!/TZ-019
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/05/hk/rv/gz/8fb786fe588b4832b675c04692f218dc.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/05/hk/rv/gz/8fb786fe588b4832b675c04692f218dc.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",足球寶貝 EP2 節目篇/射門性愛PK戰!/TZ-019
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g6/6h/ck/7m/ff4c1bf81c6e46f8be8eb9583e7fb1de.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g6/6h/ck/7m/ff4c1bf81c6e46f8be8eb9583e7fb1de.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",足球寶貝 EP1 AV篇/浴室幻引亂入3P!/TZ-018
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kz/5b/mg/qn/1193284017214f67be5d9eb6190b7aed.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kz/5b/mg/qn/1193284017214f67be5d9eb6190b7aed.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",足球寶貝 EP1 節目篇/黃牌警告指尖高潮!/TZ-018
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g0/b7/5c/n7/8055fa0c4416489192c7d58e1eace119.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g0/b7/5c/n7/8055fa0c4416489192c7d58e1eace119.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP4 AV篇/玩弄黑丝美腿粉红嫩穴!/TZ-017
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/pg/h0/o5/6q/282ca8914a994cc7a0bee2e6622a8d58.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/pg/h0/o5/6q/282ca8914a994cc7a0bee2e6622a8d58.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP4 節目篇/狂舔粉嫩美穴淫水四溢/TZ-017
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/6x/j9/3g/je/71af3251f0694c3d9a4fc5613e48d6ec.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/6x/j9/3g/je/71af3251f0694c3d9a4fc5613e48d6ec.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP3 AV篇/无套后入丰满极品翘臀!/TZ-016
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/gd/0c/bx/4o/9ae0eb567cd2474c8253e9314347abe0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/gd/0c/bx/4o/9ae0eb567cd2474c8253e9314347abe0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP3 節目篇/巨乳御姐淫荡口交!/TZ-016
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/mw/o9/7d/hj/f1f97d6765be466ea71a757623cc4602.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/mw/o9/7d/hj/f1f97d6765be466ea71a757623cc4602.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP2 AV篇/无套速插高潮内射!/TZ-015
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tb/u1/1e/8v/b97b752303934b6eba247d36e794ce84.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tb/u1/1e/8v/b97b752303934b6eba247d36e794ce84.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP2 節目篇/軟嫩美女強制高潮!/TZ-015
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lr/yn/7p/m5/063fac4cadfc4757ae0fc39de1e908f6.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lr/yn/7p/m5/063fac4cadfc4757ae0fc39de1e908f6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP1 AV篇/絕美素人後入AV初體驗!/TZ-014
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0g/xz/kh/z1/8497ec4327e64154be392d54fac27d80.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0g/xz/kh/z1/8497ec4327e64154be392d54fac27d80.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",中日大對抗 EP1 節目篇/難以抑制的指交高潮!/TZ-014
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/eb/cv/wq/dh/2f3a95db79e8485f92de4e1dbd27be98.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/eb/cv/wq/dh/2f3a95db79e8485f92de4e1dbd27be98.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足EP3/乾爹情趣調教贈禮!/TZ-013
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/o9/9l/u1/zi/75061ae3724842c8bfafe0acad6274fc.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/o9/9l/u1/zi/75061ae3724842c8bfafe0acad6274fc.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP2/潮吹噴發的乾爹調教!/TZ-012
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yh/rf/go/z5/f4fe59641f854fd38ca03b0f2fb5f696.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yh/rf/go/z5/f4fe59641f854fd38ca03b0f2fb5f696.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",爸氣十足 EP1/乾爹撒錢約會性愛!/TZ-011
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/aa/90/um/un/1d8bface8eb742ce9e6f8b5242fdbcde.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/aa/90/um/un/1d8bface8eb742ce9e6f8b5242fdbcde.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",全裸相親實驗室/徹底釋放深入探尋性愛慾望/Tz-010
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/eee/eee9789b59dc8ac2643c45986496d478/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/eee/eee9789b59dc8ac2643c45986496d478/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",性感家教被下春藥/3p瘋狂輸出內射/TZ-009
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/a3e/a3edc91ce1acccf42fe2f9ebbe3ba92c/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/a3e/a3edc91ce1acccf42fe2f9ebbe3ba92c/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",街邊搭訕兼職巨乳人妻/帶回酒店無套爆操內射/TZ-008
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/262/2623c395f21e5fdbb4b6d617a020acf1/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/262/2623c395f21e5fdbb4b6d617a020acf1/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",可爱女生初次面试/竟被禽兽老板揉虐/TZ-007
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/236/2365bb78046149e1acbd4e2553ac8ee1/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/236/2365bb78046149e1acbd4e2553ac8ee1/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",拉麵店搭訕超可愛少女(下)/帶回酒店玩弄輸出內射/TZ-006
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/9eb/9ebb7b61475fce07012660e7cffd9ab2/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/9eb/9ebb7b61475fce07012660e7cffd9ab2/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",拉麵店搭訕超可愛少女(上)/受虐少女激爽 三穴強行插入/TZ-005
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/49a/49a7ad76b17274772e17e0461003f5ab/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/49a/49a7ad76b17274772e17e0461003f5ab/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",萬聖節激情四射/不給糖就榨精/TZ-004
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/0a8/0a81f80044bba7dbd8335b9cc5a4b8df/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/0a8/0a81f80044bba7dbd8335b9cc5a4b8df/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",我的女友是女優/女友是AV女優是怎樣的體驗?/TZ-003
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/338/338723747fab14c9e8f3c83336668d12/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/338/338723747fab14c9e8f3c83336668d12/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",渣男欠債不還/讓女友用身體來還債,4P無套內射/TZ-002
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/62d/62d387d79e331ff172be735157c9ffe5/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/62d/62d387d79e331ff172be735157c9ffe5/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="兔子先生",日本街頭搭訕女大學生拍攝AV/TZ-001
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/a54/a544cf32e99035a296fb8ca5a2922cd6/m3u8/index.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/media/upload-video/a54/a544cf32e99035a296fb8ca5a2922cd6/m3u8/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「二郎探花」纹身女孩涩感十足 身材匀称肤白 弹
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/kd/hz/v1/gw/aafb04ca2014407e9e6a1a4693394295.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/kd/hz/v1/gw/aafb04ca2014407e9e6a1a4693394295.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「二郎探花」巨乳少妇荡气痴缠 千柴烈火破套内射
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/ky/qr/gn/sw/92f194c0c0844882afae0434241ba14b.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/ky/qr/gn/sw/92f194c0c0844882afae0434241ba14b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",[二郎探花」兔牙美眉娇俏可爱 换位深插内射溢出
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/gr/dl/pd/zd/3c38b8d406e142f1aa835ccda43cc68a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/gr/dl/pd/zd/3c38b8d406e142f1aa835ccda43cc68a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「二郎探花」娇嫩少女娇声绝顶页 泪眼迷离忘我舌吻
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/qh/kk/qd/1b/326a513023a744ef83f2d2afd98bcd72.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/qh/kk/qd/1b/326a513023a744ef83f2d2afd98bcd72.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",[推车探花」气质模特性感妩媚 美腿丰臀叫声可射
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/tz/mr/dt/1i/d9e6ab2f62e342eab2a0413e5bb4bfd9.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/tz/mr/dt/1i/d9e6ab2f62e342eab2a0413e5bb4bfd9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",[猛牛探花」活力少女肉感Q弹翘臀美腿淫声不止
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/0n/f7/w6/3d/9ef31674583e49aa96d75f3c019eac92.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/0n/f7/w6/3d/9ef31674583e49aa96d75f3c019eac92.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「二郎探花」JK少女媚力四射 玉腿粉穴五套摩擦
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/yh/4b/7i/a2/4bf3bb229fb84cb1ae588b08a3b1cfdd.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/yh/4b/7i/a2/4bf3bb229fb84cb1ae588b08a3b1cfdd.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",[推车探花」娇羞萝莉吟春不止 玉乳蛮腰马达电臀
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/0i/sp/qv/vg/0324b53a967e44b5949f32a32997432e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/0i/sp/qv/vg/0324b53a967e44b5949f32a32997432e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」肤白貌美极品模特 黑丝美腿窈窕身材
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/ph/9a/u6/nj/26ee6ad56ae1450fbe1977dcc2674350.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/ph/9a/u6/nj/26ee6ad56ae1450fbe1977dcc2674350.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「推车哥探花」窈窕软妹酥胸乱跳 极品身材前凸后翘
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/lg/36/43/id/dbd5aa9ed32246efb3ac01b1455b335f.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/lg/36/43/id/dbd5aa9ed32246efb3ac01b1455b335f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「推车哥探花」清纯小妹矫嗔绝顶 老汉推车横冲直撞
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/2l/tb/7j/hs/81cf27424e764b8aa117e39b38b61795.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/2l/tb/7j/hs/81cf27424e764b8aa117e39b38b61795.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」长腿学生娇羞不已 吸舔取精爱不释手
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/n4/rf/lp/e2/7087f6a7dea2411eaeec0b2db6ed2a87.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/n4/rf/lp/e2/7087f6a7dea2411eaeec0b2db6ed2a87.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「推车哥探花」十九年华如花似玉 细嫩花径淫战大屌
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/wi/bx/er/sc/1c36a41235dc42a38e7196bf42741665.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/wi/bx/er/sc/1c36a41235dc42a38e7196bf42741665.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「推车哥探花」银铃少女娇喘不停 青春肉体紧致丝滑
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/a7/07/bp/tm/5f16505b988c42bebce748911fdc4dfd.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/a7/07/bp/tm/5f16505b988c42bebce748911fdc4dfd.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」妩媚人妻风韵犹存 肤白腿长初次兼职
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/de/3b/54/rk/59ec51ac937847b4bdf1b6f5434083e7.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/de/3b/54/rk/59ec51ac937847b4bdf1b6f5434083e7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「推车哥探花」含鲍待放吹弹可破 娇羞少女眉眼怀春
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/4t/v5/4a/1b/4202a0d3eded460fa7f63eff9b8ba79c.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/4t/v5/4a/1b/4202a0d3eded460fa7f63eff9b8ba79c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老牛探花」巧舌如骚穴意乱情迷 湿滑少女浪荡发情
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/e0/t7/6y/xc/fdea107def0d40038c059ab30f5812e9.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/e0/t7/6y/xc/fdea107def0d40038c059ab30f5812e9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老牛探花」红唇少女浴火难耐 紧致花径吞茎不停
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/71/yy/se/w2/f5fd2cbb85e84e55bdc1495471df8f24.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/71/yy/se/w2/f5fd2cbb85e84e55bdc1495471df8f24.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老牛探花」长腿美臀完美炮架 邻家女孩呜咽不止
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/zf/f8/mx/hm/6e4898e298ee417cb6dea6d80d5660bf.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/zf/f8/mx/hm/6e4898e298ee417cb6dea6d80d5660bf.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」冰山美人热穴喷涌 娇俏黑丝秀色可餐
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/et/kp/3e/rt/ef6025810a8c4a5292dc8d5f37864654.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/et/kp/3e/rt/ef6025810a8c4a5292dc8d5f37864654.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「大屌探花」麻豆大屌长枪出洞 丰满少妇久旱甘露
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/8c/3b/u1/md/a5afd10dd0b945d2bc8ad4e69fca9684.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/8c/3b/u1/md/a5afd10dd0b945d2bc8ad4e69fca9684.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」修长美腿精致玉穴 怀春少女翘臀以待
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/92/ll/px/gd/4e87bac4400a4224b23401acbd5333bc.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/92/ll/px/gd/4e87bac4400a4224b23401acbd5333bc.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老牛探花」豪乳女孩水波荡漾 蜂腰玉腿极乐享受
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/sd/l2/63/as/bef0c2dd59bb4c88a1c816a817f8a2da.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/sd/l2/63/as/bef0c2dd59bb4c88a1c816a817f8a2da.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」翘臀长腿情趣诱惑 苗条骚女腰肢乱颠
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/me/t0/dw/jn/5d7210353dc0423181c93f9759f2aabf.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/me/t0/dw/jn/5d7210353dc0423181c93f9759f2aabf.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」痴男荡妇白日宣淫 黑丝长腿无套内射
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/fy/5q/in/5w/8ccac0abb75149f4a858ac740a8f345b.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/fy/5q/in/5w/8ccac0abb75149f4a858ac740a8f345b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「推车哥探花」花言巧语勾引挑逗 花季少女惨遭无套
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/2d/me/7b/eq/e4a277a77f1249c79adb84b6badf6ea5.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/zh/2d/me/7b/eq/e4a277a77f1249c79adb84b6badf6ea5.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「推车哥探花」温婉可人口技一流 气质美人极致服务
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/je/z7/ft/ou/4d5dd95c4f55404ab77f081b4f1d9615.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/je/z7/ft/ou/4d5dd95c4f55404ab77f081b4f1d9615.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」懵懂少女绝顶失神 玉腿横陈少经床事
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ov/ph/4g/76/6adb951aded14269b9c0c82d3955251d.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/ov/ph/4g/76/6adb951aded14269b9c0c82d3955251d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「 老司机探花」胸大腰细眉眼如丝 母狗网红发情求欢
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/45/j2/e6/mp/fe17bcf982824ca9b151759f88e8320f.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/45/j2/e6/mp/fe17bcf982824ca9b151759f88e8320f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」开档内裤骚气四溢 饥渴少妇摇尾乞怜
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/92/x3/zv/xk/819b2bef59db48f88d418f2d6cf1f267.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/92/x3/zv/xk/819b2bef59db48f88d418f2d6cf1f267.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」舔奶玩逼金枪不倒 短发少女娇喘求饶
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qd/2n/zm/q4/88988149c1b047fd8f15752920374bd2.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qd/2n/zm/q4/88988149c1b047fd8f15752920374bd2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」巨乳尤物波涛汹涌 微醺探花越战越勇
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/yw/5y/ov/aw/5b968c1bdd7049fba2b810fee4b4fcbc.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/yw/5y/ov/aw/5b968c1bdd7049fba2b810fee4b4fcbc.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」翘臀美腿爱不释手 黑丝网红娇声难耐
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/g7/ja/19/uh/bfa6ada6684f4b44a7366f1ed14498d9.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/g7/ja/19/uh/bfa6ada6684f4b44a7366f1ed14498d9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」麻豆腥春历险记 红粉少女上工挨操
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/rq/uz/1v/1o/b1708195840a4c63a37fc8867110bfdc.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/rq/uz/1v/1o/b1708195840a4c63a37fc8867110bfdc.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」肉感肥臀妙不可言 丰韵网红骚气四溢
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qp/u5/6h/1c/42a37ff2f7344e70b4d3e3c3dbf3fe8d.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qp/u5/6h/1c/42a37ff2f7344e70b4d3e3c3dbf3fe8d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」射区探花淫新春 蕾丝欲兔开工迎春
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/98/yf/z1/55/67015a5b1ee64694bfdb5668f2a78299.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/98/yf/z1/55/67015a5b1ee64694bfdb5668f2a78299.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」射区探花淫新春 旗袍洋马胯下娇嗔
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/wd/gc/po/od/7b9b1fb3acb44fc0898b1adcac8efb43.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/wd/gc/po/od/7b9b1fb3acb44fc0898b1adcac8efb43.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」花言巧浯无套插入 肉感少女惨遭内射
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/r5/ko/rq/27/c6bc23738f6e42809b0a5ae81ffd4e5a.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/r5/ko/rq/27/c6bc23738f6e42809b0a5ae81ffd4e5a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」高冷兼职娇俏面容 辣手摧花毫不留情
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/fp/cs/kg/in/9024167783e041389c8b00e572088d43.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/fp/cs/kg/in/9024167783e041389c8b00e572088d43.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「山鸡探花」细狗女孩娇声不停 失恋之夜饥渴求欢
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/kd/y1/jz/8s/b93cbc507f8d43d6b39f487cbd7a4439.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/kd/y1/jz/8s/b93cbc507f8d43d6b39f487cbd7a4439.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「山鸡探花」麻豆山鸡雄风大振 娇乳少妇丢盔泄甲
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/64/00/bq/xs/a793c7ac2247462dbfff5d92fe9258ff.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/64/00/bq/xs/a793c7ac2247462dbfff5d92fe9258ff.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」射区圣涎礼炮响 同胞姐妹淫乱狂炊
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/55/x7/80/ac/2a11588844fe4402b1c7bf7697b892c4.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/55/x7/80/ac/2a11588844fe4402b1c7bf7697b892c4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」跨年礼炮淫新年 娇俏少妇秀色可餐
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/fx/hh/xl/47/f67860994f5347fa9bc2b3f58b2d1e44.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/fx/hh/xl/47/f67860994f5347fa9bc2b3f58b2d1e44.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「射区独家探花-老司机探花」射区圣诞礼炮响 骚女淫声平安液
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/x9/kg/0w/ai/018d047b423a4b50bfb80764fdd9eab6.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/x9/kg/0w/ai/018d047b423a4b50bfb80764fdd9eab6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」全新视角体验升级 黑丝OL乳隐乳现
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qd/nx/um/wk/9ab01879df7b4524b4b64fae9f2e6704.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/qd/nx/um/wk/9ab01879df7b4524b4b64fae9f2e6704.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」甜美笑容惹人怜爱 巨乳嫩妹水流成河
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/fk/4p/yl/y0/729b10923f214f1582fb6213ac965ad2.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/fk/4p/yl/y0/729b10923f214f1582fb6213ac965ad2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」老司机爆草阿根廷 足球宝贝活力思春
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/zp/2z/fg/tb/0db897893c394885bdb07e456286905b.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/zp/2z/fg/tb/0db897893c394885bdb07e456286905b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」老司机老牛新春 花季少女欲拒还迎
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/w7/ma/wv/pq/423c13da495c416c96b38a1ed0bb91b6.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/w7/ma/wv/pq/423c13da495c416c96b38a1ed0bb91b6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「大鸟探花」麻豆大鸟火速归队御姐技师极致服
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/jp/a5/r6/2m/e2a1ce9c1c73491b9f670d383b26e7fa.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/jp/a5/r6/2m/e2a1ce9c1c73491b9f670d383b26e7fa.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」老司机金枪不倒 肉感美妇饥渴乘骑
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/05/lb/ey/xq/563973dc980647ce8f62c4fe80cae4c0.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/05/lb/ey/xq/563973dc980647ce8f62c4fe80cae4c0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」老司机飞行体验 高冷空乘黑丝求爱
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/hz/q0/p4/xh/9c400befeed34d6ab4bdb47111f6986b.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/hz/q0/p4/xh/9c400befeed34d6ab4bdb47111f6986b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」小文爱恋初体验软萌少女羞色回应
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/4u/i1/0k/r5/be13b323bef141a7b188f70d20f91f99.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/4u/i1/0k/r5/be13b323bef141a7b188f70d20f91f99.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」 无套内射解禁 淫荡尤物口技封神
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/k3/gj/33/mk/56495ca3a195450a86936ad1bb13d879.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/k3/gj/33/mk/56495ca3a195450a86936ad1bb13d879.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」丰臀骚货吹拉弹唱 老司机欲罢不能
-https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/k3/gj/33/mk/56495ca3a195450a86936ad1bb13d879.m3u8?
+https://fufxtyc.bytebwq.com/api/app/media/m3u8/zh/k3/gj/33/mk/56495ca3a195450a86936ad1bb13d879.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」黑丝浪女骚淫服务 深入浅出娇声不停
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/t7/9l/gp/1l/8c767cf9fc834a52a80694848e0e01ef.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/t7/9l/gp/1l/8c767cf9fc834a52a80694848e0e01ef.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机」梅开二度 骚浪美人黑丝诱惑
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/2b/1m/d5/3b/52fcdeb74e6d4a81a1233fa81edba00a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/2b/1m/d5/3b/52fcdeb74e6d4a81a1233fa81edba00a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「小文探花」淫荡少女贴身肉勃 湿声浪叫不绝子耳
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/g1/jz/4l/tb/fd78317e705342f19c14be7a94c40da3.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/g1/jz/4l/tb/fd78317e705342f19c14be7a94c40da3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「老司机探花」性感御姐掰穴插逼 私密部位一览无遗
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/e8/uy/pp/0d/597e20a7cd1b4f4b9141d90af3df1471.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/e8/uy/pp/0d/597e20a7cd1b4f4b9141d90af3df1471.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-探花",「银先生探花」美乳少妇极致后入口交 多体位高清偷拍
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/t7/9l/gp/1l/8c767cf9fc834a52a80694848e0e01ef.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/zh/t7/9l/gp/1l/8c767cf9fc834a52a80694848e0e01ef.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-0161/防火防盜防闺蜜
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/m7/8t/hq/kv/da306e5145c64c8f9ae5e0c61fb33fd7.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/m7/8t/hq/kv/da306e5145c64c8f9ae5e0c61fb33fd7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-159/寂寞白领猎艳江湖小盜/小偷取金不成遭取精
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/gp/ha/qb/x9/27117964739c4f668d91c78def6ea7ca.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/gp/ha/qb/x9/27117964739c4f668d91c78def6ea7ca.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-137/热恋情侣重聚炮
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/x3/q1/02/vg/a3f1a279e76f4d59b1a8f83ee1848570.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/x3/q1/02/vg/a3f1a279e76f4d59b1a8f83ee1848570.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-139/沉迷乱伦的风骚继母 / 爱上继子的精液味
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/57/zh/x9/6s/2894b46efbb14ba49c9d09923c15c8ee.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/57/zh/x9/6s/2894b46efbb14ba49c9d09923c15c8ee.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-134/九头身长腿新玩法 / 浅尝瑜伽裤下出汗蜜穴
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/ax/40/k7/y1/237063f300bd45febc31a23d1bce786a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/ax/40/k7/y1/237063f300bd45febc31a23d1bce786a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-141/内射我的夢莉同事
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/92/qk/yd/6v/e6e01530d0b74d40978753be00d9fc94.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/92/qk/yd/6v/e6e01530d0b74d40978753be00d9fc94.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-145/调教心机女员工
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/fg/ky/sx/0r/c220cb9de18345e59392d39439d57ed1.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/fg/ky/sx/0r/c220cb9de18345e59392d39439d57ed1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-158/中出玉足粉鲍苗族妹妹
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/pu/si/zs/s0/f1b62b8455744458ae8ba2a42693eac9.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/v2/av/pu/si/zs/s0/f1b62b8455744458ae8ba2a42693eac9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-133/狠操长腿肥臀警花
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jw/b5/rn/e6/c1c566a8d19e4aa68237de45cec8e2ff.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jw/b5/rn/e6/c1c566a8d19e4aa68237de45cec8e2ff.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-135/欲求不满风韵后妈
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/8j/mh/ul/05/f85b7d6d22444d29a8de6787bcb62818.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/8j/mh/ul/05/f85b7d6d22444d29a8de6787bcb62818.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-132/黑丝浪姐遭精液洗面
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/zm/ap/l1/5i/4625b2c714b441b0a8ef5a7973df5f9c.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/zm/ap/l1/5i/4625b2c714b441b0a8ef5a7973df5f9c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-131/清纯少女嫩逼飘香
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/k6/nt/2y/yj/f4d6fe2e1adf4819a8d29e39679d0328.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/k6/nt/2y/yj/f4d6fe2e1adf4819a8d29e39679d0328.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-129/越南女房东仲卖房送逼
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/j0/7s/4p/vv/60ced8a0e5c24573a97d339e9efb38ea.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/j0/7s/4p/vv/60ced8a0e5c24573a97d339e9efb38ea.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-128/美足痴女的阳痿疗程
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/th/l5/u1/aq/345fb9e3c56445e38e019cca7bfb7878.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/th/l5/u1/aq/345fb9e3c56445e38e019cca7bfb7878.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-127/黑丝少妇吞白精
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/qp/oo/jy/ir/d9f2e4a24e894f498310b8d9e44118f3.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/qp/oo/jy/ir/d9f2e4a24e894f498310b8d9e44118f3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-126/痴女主播吞精饮尿
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/h3/c4/2v/sv/a6d11f81d30a41e7a966cb10b04c8fc9.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/h3/c4/2v/sv/a6d11f81d30a41e7a966cb10b04c8fc9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-125/姐弟之间不伦之恋
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/4i/w4/zv/dh/6d2ee84e829447869d25d54d5287187d.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/4i/w4/zv/dh/6d2ee84e829447869d25d54d5287187d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-124/电竞陪玩少女的秘密
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/i5/rt/87/w4/e28e28664294478788ca9617eda19c81.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/i5/rt/87/w4/e28e28664294478788ca9617eda19c81.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-123/黑丝御姐温情榨精
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/zc/ox/s3/jk/cda3420e41394ada8738fb478e3d702b.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/zc/ox/s3/jk/cda3420e41394ada8738fb478e3d702b.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-122/美乳白虎高潮失禁
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/fn/vi/fn/ox/3221872b6f424be5a2cef6a789ffec94.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/fn/vi/fn/ox/3221872b6f424be5a2cef6a789ffec94.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-119/你老婆操起来真香
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/c7/fw/q9/si/ac4ab7c6392149c3a3f9294407f3d542.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/c7/fw/q9/si/ac4ab7c6392149c3a3f9294407f3d542.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-117/狼叔迷奸黑丝侄女
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/40/ku/6i/yo/fa7633f87abf4638b048ec469d4188c3.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/40/ku/6i/yo/fa7633f87abf4638b048ec469d4188c3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-116/黑丝房客纯爱艳遇
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/bo/26/m5/ue/0315cfd039da4791a686892b4ada8255.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/bo/26/m5/ue/0315cfd039da4791a686892b4ada8255.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-114/口爆童颜巨乳嫩妹
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yb/9e/kr/j1/28c0d9c657a74a5c8be6a799eac8b201.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yb/9e/kr/j1/28c0d9c657a74a5c8be6a799eac8b201.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-113/爽操少妇喷白浆
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9o/w7/qp/4a/4ec0964678e645ce89eef69903c719e1.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9o/w7/qp/4a/4ec0964678e645ce89eef69903c719e1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-112/惹火上门按摩
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9m/p7/v3/bo/b72ab2435d384fee9f620eb908911c51.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9m/p7/v3/bo/b72ab2435d384fee9f620eb908911c51.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-110/肉臀学姐上位榨精
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qk/2p/5h/s0/b14f9cce57684362ade1fd00c9833528.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qk/2p/5h/s0/b14f9cce57684362ade1fd00c9833528.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-108/看着姐姐给人操
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0h/87/t2/ap/2eaf34126e304659927ca047da48907e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0h/87/t2/ap/2eaf34126e304659927ca047da48907e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-107/丈夫当家是炮房
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8c/hz/z5/xc/587c43e791b244559f5b66737d6ca870.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8c/hz/z5/xc/587c43e791b244559f5b66737d6ca870.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-106/我的裸体室友
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9f/75/sj/0g/0a7e3eac418c47cbbd8fb1061bc3ec28.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/9f/75/sj/0g/0a7e3eac418c47cbbd8fb1061bc3ec28.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-105/黑脸王的淫行逆袭
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/fp/c7/yx/2t/7e1116b8df4940df836ca2e31b80e779.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/fp/c7/yx/2t/7e1116b8df4940df836ca2e31b80e779.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-104/诱人的家教老师
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/gf/ai/5g/hw/174350035e6843cf9e9af38ae2400bf6.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/gf/ai/5g/hw/174350035e6843cf9e9af38ae2400bf6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-096/侵犯骚货亲姐
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/l8/ne/uj/lt/38632e4f63f54ae6ae03fa036a845b87.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/l8/ne/uj/lt/38632e4f63f54ae6ae03fa036a845b87.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-090/兼职管家婆
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/su/vl/xg/f6/b5cb9d3fee2344f3b600a33ddb4c5630.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/su/vl/xg/f6/b5cb9d3fee2344f3b600a33ddb4c5630.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-089/鬼畜前任的威胁
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tx/dr/qe/np/adcb9781dfaa4d6c9145780722df6a44.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tx/dr/qe/np/adcb9781dfaa4d6c9145780722df6a44.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-088/表姐的诱惑
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/x9/ag/h0/pi/08093f19f76b428487e20398acc62011.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/x9/ag/h0/pi/08093f19f76b428487e20398acc62011.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-087/今晚老公不在家
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0j/n8/f6/cl/bcc0bb45102f46b0976a8f405a1229c9.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0j/n8/f6/cl/bcc0bb45102f46b0976a8f405a1229c9.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-085/最后的激情性爱
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cs/qk/e8/jb/31d3a61348b94a97821c31c426427f79.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cs/qk/e8/jb/31d3a61348b94a97821c31c426427f79.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-081/黑道大哥操我逼
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/vt/xv/q6/er/368e295dd4a34303bac04a58bea5af53.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/vt/xv/q6/er/368e295dd4a34303bac04a58bea5af53.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-080/老师...我还要
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/v6/9z/ct/96/b77f4f8befe24e4190fa5687ec935f08.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/v6/9z/ct/96/b77f4f8befe24e4190fa5687ec935f08.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-079/色气保险员
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uq/vb/9o/3y/3d545bfa0a804c2a93b36e37147d27d0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uq/vb/9o/3y/3d545bfa0a804c2a93b36e37147d27d0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-078/纯爱恋歌
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ui/tv/b9/8t/77aff3eec0d24cd9acd60eb998b2f3ce.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ui/tv/b9/8t/77aff3eec0d24cd9acd60eb998b2f3ce.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-074/粉逼美乳淫荡献情
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/qu/3t/o2/f0/b743657ec67b4f9aae1f281daa453f90.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/qu/3t/o2/f0/b743657ec67b4f9aae1f281daa453f90.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-072/发小换错身
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/or/6p/qg/6e/bc55c595b94b4759b92cda6aacc71db6.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/or/6p/qg/6e/bc55c595b94b4759b92cda6aacc71db6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-071/少爷的乖女仆
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/3x/m7/vg/zv/d17a8774cb1140a5bfaf3fabde47900e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/3x/m7/vg/zv/d17a8774cb1140a5bfaf3fabde47900e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-070/人妻红杏出墙
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lj/ve/2d/rn/c64b512189904112940b5b4888f4393a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lj/ve/2d/rn/c64b512189904112940b5b4888f4393a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-069/旗袍女神
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/do/bt/pm/lf/ca59bde94b9a424395bacac427da1acb.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/do/bt/pm/lf/ca59bde94b9a424395bacac427da1acb.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-068/外约对象是弟媳
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/xq/m8/6j/ah/9346d658c3814efbb414c4de599db54e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/xq/m8/6j/ah/9346d658c3814efbb414c4de599db54e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-066/父亲花钱买下的女人
-https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/dt/z1/iw/zw/2ac9602ba6ad43afbe82fa4d9e04e691.m3u8?
+https://gcyivjc.qrneryt.com/api/app/media/m3u8/av/dt/z1/iw/zw/2ac9602ba6ad43afbe82fa4d9e04e691.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-065/应酬潜规则
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/51/42/uz/c4/98fb9291181b4f7ab3df9fa22b6ffca6.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/51/42/uz/c4/98fb9291181b4f7ab3df9fa22b6ffca6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-064/淫荡的新邻居
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tl/mg/mz/k1/59f6ab1fd5e04614bdbc35abbeb0a903.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tl/mg/mz/k1/59f6ab1fd5e04614bdbc35abbeb0a903.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-061/羞涩处女遭入侵
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ge/i5/3q/ce/d111c578dd7e44409229536f528263a4.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ge/i5/3q/ce/d111c578dd7e44409229536f528263a4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-060/威胁强上高冷女子
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/sz/7v/wo/yl/fa23ff941d04477cb8192d40ef1ee012.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/sz/7v/wo/yl/fa23ff941d04477cb8192d40ef1ee012.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-059/出差艳遇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7x/xn/vl/o1/30cc6b1cfc7d46beb4d946f02c724794.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7x/xn/vl/o1/30cc6b1cfc7d46beb4d946f02c724794.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-058/催情迷幻药水
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/r6/he/r3/7i/57f718eb5bdd420ca5d26d367107f8d7.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/r6/he/r3/7i/57f718eb5bdd420ca5d26d367107f8d7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-057/小模特私房约炮
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g3/gh/zk/yt/a20456ea59ef464b8f2fbc87adf5a680.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g3/gh/zk/yt/a20456ea59ef464b8f2fbc87adf5a680.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-056/清纯少女邻居
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/br/69/uw/fm/5b9fd6c3100e4328bd954b1a1c35d4d4.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/br/69/uw/fm/5b9fd6c3100e4328bd954b1a1c35d4d4.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-055/淫•许愿精灵
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/y3/ot/av/9k/b6aeb152486f4a4db98958148a7b86a8.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/y3/ot/av/9k/b6aeb152486f4a4db98958148a7b86a8.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-054/女秘书性爱商谈
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ea/4b/7l/8e/8b8ff4c880634b48abbbc21f60a5ab56.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ea/4b/7l/8e/8b8ff4c880634b48abbbc21f60a5ab56.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-053/敲诈性感人妻
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cv/m0/r8/ud/8f4c0a5c71284fbe82e1ccbfc74a3662.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/cv/m0/r8/ud/8f4c0a5c71284fbe82e1ccbfc74a3662.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-052/肉欲宣泄失恋女
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/h6/tp/mc/96/c3d66c25da564a6aaaba7b16580de302.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/h6/tp/mc/96/c3d66c25da564a6aaaba7b16580de302.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-051/春药试用女郎
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0y/uc/d9/g0/73f07ec9093e4540bcc376dd30b88cf2.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0y/uc/d9/g0/73f07ec9093e4540bcc376dd30b88cf2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-050/诱人女教师
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tc/49/ms/op/e71acef0b5a646f180f6940e127313fd.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tc/49/ms/op/e71acef0b5a646f180f6940e127313fd.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-049/调教女仆美娇妻
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yl/9t/f5/2m/32c0dab07a464ff7ad80b30d5e72c0fe.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/yl/9t/f5/2m/32c0dab07a464ff7ad80b30d5e72c0fe.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-048/人妻肉便器
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0i/gm/jf/fm/22ddb1ee85dd49caa736899ffd4c9f6d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/0i/gm/jf/fm/22ddb1ee85dd49caa736899ffd4c9f6d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-047/强偷相奸OL
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1i/55/za/e1/0318bfd04ad74137bd253eacd7b28cc0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1i/55/za/e1/0318bfd04ad74137bd253eacd7b28cc0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-046/足浴小妹的性服务
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/nm/y0/13/x5/e9be0274701d4d58874ca6663f6bee99.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/nm/y0/13/x5/e9be0274701d4d58874ca6663f6bee99.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-045/女上司骚气反差
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/td/e8/d6/yb/4339d805dd084e9e9da578cb5b1a25b2.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/td/e8/d6/yb/4339d805dd084e9e9da578cb5b1a25b2.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-044/顺从欲望之夜
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/71/8s/qb/29/160a6197bc9d4d06aa956077055d9ba7.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/71/8s/qb/29/160a6197bc9d4d06aa956077055d9ba7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-043/青春盛宴
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/w8/2g/op/ee/94d65ada2d77477faf2df41469188390.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/w8/2g/op/ee/94d65ada2d77477faf2df41469188390.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-042/交换女友
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/dt/u1/ra/aa/8eecbe9546ce4457835499adc52c9226.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/dt/u1/ra/aa/8eecbe9546ce4457835499adc52c9226.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-041/JK主播的迷奸餐
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/rc/ka/e6/z9/64b8001bb54a44818761fcfdf29b22db.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/rc/ka/e6/z9/64b8001bb54a44818761fcfdf29b22db.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-040/朋友以上恋人未满
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lf/2a/on/ol/ce941bc5ab0041848620f614a95a8eaf.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lf/2a/on/ol/ce941bc5ab0041848620f614a95a8eaf.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-039/约会前出轨背叛
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/d8/4v/90/f4/78344d0527b04d8b8a939d7d0863ac9e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/d8/4v/90/f4/78344d0527b04d8b8a939d7d0863ac9e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-038/空姐的飞淫之旅-奢糜篇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uk/41/i7/xt/8a50b81be9394dd3b03916bd37c7c89e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/uk/41/i7/xt/8a50b81be9394dd3b03916bd37c7c89e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-037/空姐的飞淫之旅-困顿篇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/m3/gn/1u/fw/45429199cdce457ebccce932ac64d5c6.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/m3/gn/1u/fw/45429199cdce457ebccce932ac64d5c6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-036/偷摄邻家淫妻
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/or/ns/ir/nm/ff8b839fc5244d119402d6951699dd80.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/or/ns/ir/nm/ff8b839fc5244d119402d6951699dd80.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-035/毒舌巨乳邻居
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/71/ck/5a/so/a571f9b1f42b4ac5b3e795c9f411857e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/71/ck/5a/so/a571f9b1f42b4ac5b3e795c9f411857e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-034/人妻堕落之路-脱变篇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g5/86/jp/2h/25bc0723329d47099fe5eb8dfbfebaf8.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/g5/86/jp/2h/25bc0723329d47099fe5eb8dfbfebaf8.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-033/人妻堕落之路-玷污篇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/fg/bp/qh/e7/5e26313114c046358132670e725bc624.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/fg/bp/qh/e7/5e26313114c046358132670e725bc624.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-032/少女的噩梦
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lw/d0/98/rh/fe9a2b7f19684982afec97e2d25ccb94.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/lw/d0/98/rh/fe9a2b7f19684982afec97e2d25ccb94.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-031/午夜电话艳遇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/be/7q/wz/yz/59c93a2ef6824b798d569a02fb0c7c6e.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/be/7q/wz/yz/59c93a2ef6824b798d569a02fb0c7c6e.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-030/兽欲交欢女学员
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/xh/bf/3k/fp/a54ddc7e93c142658c99dbd7d4129389.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/xh/bf/3k/fp/a54ddc7e93c142658c99dbd7d4129389.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-029/淫乱加班维修工
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2m/3e/e7/0o/e7b4f58df3b14284bd274b23a2d7455f.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2m/3e/e7/0o/e7b4f58df3b14284bd274b23a2d7455f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-028/课后性爱辅导
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/5f/7o/to/mb/cdcebd2d1a7e4c948d5b83324fa8c383.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/5f/7o/to/mb/cdcebd2d1a7e4c948d5b83324fa8c383.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-026/奥运迷妹小少妇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/t7/k0/yd/wr/6af067b22d3a4fa293197c746c72c860.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/t7/k0/yd/wr/6af067b22d3a4fa293197c746c72c860.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-025/赔罪...潜规则
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jy/cn/1d/2q/cf4836c5c81c4fa5825e0687c0ea9fd0.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/jy/cn/1d/2q/cf4836c5c81c4fa5825e0687c0ea9fd0.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-024/流量明星的爱
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qj/qg/c8/1f/a09e527b128740cc8c62f1052016f11d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qj/qg/c8/1f/a09e527b128740cc8c62f1052016f11d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-023/可爱女孩非亲妹
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/wl/to/ad/9f/dc39daa9de9b42598d40fb7ca3a74fc3.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/wl/to/ad/9f/dc39daa9de9b42598d40fb7ca3a74fc3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-022/大学的性福生活
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2d/o0/13/7p/b07235b957a747c1afbf11910a256b2d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/2d/o0/13/7p/b07235b957a747c1afbf11910a256b2d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-021/绝望的肉偿债款
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1p/0d/vb/yr/9c438f5074594706ac140779b12f819d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/1p/0d/vb/yr/9c438f5074594706ac140779b12f819d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-020/强奸暗恋同学
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/or/7b/8n/36/b5b8ee76c8fb4212854aed70080f7840.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/or/7b/8n/36/b5b8ee76c8fb4212854aed70080f7840.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-019/女神的秘密(下)
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/nv/sm/ah/n7/430f6ca997ed4755b97de404d789cea3.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/nv/sm/ah/n7/430f6ca997ed4755b97de404d789cea3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-018/女神的秘密(上)
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8d/1t/5n/p5/e1d6f1edaf194f0bbbe62bffa2a93df5.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/8d/1t/5n/p5/e1d6f1edaf194f0bbbe62bffa2a93df5.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-016/强奸温柔嫂子
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/hk/j4/rf/hb/96198f63d1ff4f68ab0bbc31748df6e7.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/hk/j4/rf/hb/96198f63d1ff4f68ab0bbc31748df6e7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-015/色从天降
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/x9/30/33/g2/354727a08a0f4ac691712573c940c79c.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/x9/30/33/g2/354727a08a0f4ac691712573c940c79c.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-014/心机拜金女
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/vp/k1/b5/2l/279f340b8c7c466a8dabdbe84d9e235a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/vp/k1/b5/2l/279f340b8c7c466a8dabdbe84d9e235a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-013/网瘾少女的日常
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/85/by/qb/w0/220c040a0b9347a6858fd341dfe4d833.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/85/by/qb/w0/220c040a0b9347a6858fd341dfe4d833.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-012/姐姐的性爱教室
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ip/sf/75/3m/d002252ad5b8498aa54af8880620715d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ip/sf/75/3m/d002252ad5b8498aa54af8880620715d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-011/劫色清纯高校生
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tc/fw/lp/in/94ca0d7766f14d6e980c05ad0df4c3e6.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/tc/fw/lp/in/94ca0d7766f14d6e980c05ad0df4c3e6.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-010/照料色欲姐夫
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ip/w0/h7/mb/d2ec1ff487ec41208d35a93e3f391cf3.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ip/w0/h7/mb/d2ec1ff487ec41208d35a93e3f391cf3.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-009/香艳姐妹新邻居
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ow/z3/5g/mg/90bb4af29a7c4e3c9d31fa75371c653d.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/ow/z3/5g/mg/90bb4af29a7c4e3c9d31fa75371c653d.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-008/出轨的妖艳少妇
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/hh/y4/uz/4k/251dd61a40324cf19846bc58f1cbff12.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/hh/y4/uz/4k/251dd61a40324cf19846bc58f1cbff12.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-007/强上仙人跳渣女
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/al/72/bl/7v/ce8b0dbdbffb4d4d8f85c538ba35c4be.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/al/72/bl/7v/ce8b0dbdbffb4d4d8f85c538ba35c4be.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-006/疯狂的女主播
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7s/37/y5/7m/714af6843aae4ff79ce7adc7980d0712.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/7s/37/y5/7m/714af6843aae4ff79ce7adc7980d0712.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-005/维修工的心跳艳遇(下)
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/60/iw/9o/jv/8f91843b009a4379bef6c824fcb3b22f.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/60/iw/9o/jv/8f91843b009a4379bef6c824fcb3b22f.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-004/妇女的不论之恋
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/eg/oc/n7/57/fbb21f9d41d54e468b7657d66b6aa6e7.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/eg/oc/n7/57/fbb21f9d41d54e468b7657d66b6aa6e7.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-003/菜鸟特务
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kn/99/yw/34/c3ac47258c9f4b7399c6a6543b80b8c1.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/kn/99/yw/34/c3ac47258c9f4b7399c6a6543b80b8c1.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-002/维修工的心跳艳遇(上)
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/gz/dp/pq/y9/acd55327c8504396a9ec4bf6050bd13a.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/gz/dp/pq/y9/acd55327c8504396a9ec4bf6050bd13a.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i2.100024.xyz/2023/09/11/11a5d62.webp" group-title="麻豆-MSD",MSD-001/乱伦迷情药
-https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qi/oi/gz/ux/dbf57474fbed49c9aa3fb97bcd75b891.m3u8?
+https://ypmnkbb.saejeuj.com/api/app/media/m3u8/av/qi/oi/gz/ux/dbf57474fbed49c9aa3fb97bcd75b891.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://z1.ax1x.com/2023/10/07/pPjTDO0.png" group-title="果冻传媒",伪装者代号91上集
 https://long.longyuandingyi.com/watch9/ae4c6df63872cf3445591b008090ef09/ae4c6df63872cf3445591b008090ef09.m3u8?auth_key=1695208759-0-0-1eb78eb6742d26c7ed1a7bb713c9f0a6
 #EXTINF:-1 tvg-logo="https://z1.ax1x.com/2023/10/07/pPjTDO0.png" group-title="果冻传媒",伪装者代号91下集

--- a/Gather.m3u
+++ b/Gather.m3u
@@ -40,41 +40,41 @@ http://[2409:8087:2001:20:2800:0:df6e:eb18]/ott.mobaibox.com/PLTV/3/224/32212281
 #EXTINF:-1 group-title="IPV6·央视",CCTV8K「IPV6」
 http://[2409:8087:2001:20:2800:0:df6e:eb03]/wh7f454c46tw1981574683_-2118700426/ott.mobaibox.com/PLTV/3/224/3221228165/index.m3u8
 #EXTINF:-1 tvg-name="CCTV1" group-title="IPV6·央视",CCTV1「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001022/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001022/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV2" group-title="IPV6·央视",CCTV2「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001220/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001220/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV3" group-title="IPV6·央视",CCTV3「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001186/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001186/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV4" group-title="IPV6·央视",CCTV4「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001221/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001221/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV5" group-title="IPV6·央视",CCTV5「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001187/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001187/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV5+" group-title="IPV6·央视",CCTV5+「IPV6」
 http://[2409:8087:7000:20:1000::22]:6060/yinhe/2/ch00000090990000001334/index.m3u8?virtualDomain=yinhe.live_hls.zte.com
 #EXTINF:-1 tvg-name="CCTV6" group-title="IPV6·央视",CCTV6「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001188/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001188/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV7" group-title="IPV6·央视",CCTV7「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001236/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001236/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV8" group-title="IPV6·央视",CCTV8「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001189/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001189/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV9" group-title="IPV6·央视",CCTV9「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001237/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001237/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV10" group-title="IPV6·央视",CCTV10「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001238/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001238/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV11" group-title="IPV6·央视",CCTV11「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001309/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001309/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV12" group-title="IPV6·央视",CCTV12「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001239/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001239/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV13" group-title="IPV6·央视",CCTV13「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001328/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001328/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV14" group-title="IPV6·央视",CCTV14「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001240/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001240/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV15" group-title="IPV6·央视",CCTV15「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001338/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001338/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV16" group-title="IPV6·央视",CCTV16「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001258/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001258/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CCTV17" group-title="IPV6·央视",CCTV17「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001241/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001241/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="兵器科技" group-title="IPV6·央视",CCTV兵器科技「IPV6」
 http://[2409:8087:7001:20:2::3]:80/dbiptv.sn.chinamobile.com/PLTV/88888893/224/3221226975/index.m3u8
 #EXTINF:-1 tvg-name="怀旧剧场" group-title="IPV6·央视",CCTV怀旧剧场「IPV6」
@@ -100,63 +100,63 @@ http://[2409:8087:7000:20:1000::22]:6060/yinhe/2/ch00000090990000002525/index.m3
 #EXTINF:-1 tvg-name="女性时尚" group-title="IPV6·央视",CCTV女性时尚「IPV6」
 http://[2409:8087:7000:20:1000::22]:6060/yinhe/2/ch00000090990000002475/index.m3u8?virtualDomain=yinhe.live_hls.zte.com
 #EXTINF:-1 tvg-name="CETV1" group-title="IPV6·央视",CETV1「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001020/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001020/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CETV4" group-title="IPV6·央视",CETV4「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001348/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001348/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="CGTV" group-title="IPV6·央视",CGTV「IPV6」
 http://[2409:8087:7000:20:1000::22]:6060/yinhe/2/ch00000090990000001024/index.m3u8?virtualDomain=yinhe.live_hls.zte.com
 #EXTINF:-1 tvg-name="湖南卫视" group-title="IPV6·卫视",湖南卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001026/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001026/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="浙江卫视" group-title="IPV6·卫视",浙江卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001023/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001023/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="江苏卫视" group-title="IPV6·卫视",江苏卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001033/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001033/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="东方卫视" group-title="IPV6·卫视",东方卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001013/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001013/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="广东卫视" group-title="IPV6·卫视",广东卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001032/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001032/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="广西卫视" group-title="IPV6·卫视",广西卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001224/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001224/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="深圳卫视" group-title="IPV6·卫视",深圳卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001030/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001030/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="北京卫视" group-title="IPV6·卫视",北京卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001029/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001029/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="东南卫视" group-title="IPV6·卫视",东南卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001201/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001201/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="四川卫视" group-title="IPV6·卫视",四川卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001130/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001130/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="天津卫视" group-title="IPV6·卫视",天津卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001036/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001036/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="安徽卫视" group-title="IPV6·卫视",安徽卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001037/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001037/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="山东卫视" group-title="IPV6·卫视",山东卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001028/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001028/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="江西卫视" group-title="IPV6·卫视",江西卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001034/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001034/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="河北卫视" group-title="IPV6·卫视",河北卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001229/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001229/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="河南卫视" group-title="IPV6·卫视",河南卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001222/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001222/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="海南卫视" group-title="IPV6·卫视",海南卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001183/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001183/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="湖北卫视" group-title="IPV6·卫视",湖北卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001027/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001027/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="贵州卫视" group-title="IPV6·卫视",贵州卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001184/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001184/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="辽宁卫视" group-title="IPV6·卫视",辽宁卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001035/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001035/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="重庆卫视" group-title="IPV6·卫视",重庆卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001129/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001129/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="甘肃卫视" group-title="IPV6·卫视",甘肃卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001298/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001298/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="吉林卫视" group-title="IPV6·卫视",吉林卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001225/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001225/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="云南卫视" group-title="IPV6·卫视",云南卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001223/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001223/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="三沙卫视" group-title="IPV6·卫视",三沙卫视「IPV6」
 http://[2409:8087:5e01:34::21]:6610/ZTE_CMS/08984400000000060000000000000319/index.m3u8?IAS
 #EXTINF:-1 tvg-name="黑龙江卫视" group-title="IPV6·卫视",黑龙江卫视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001031/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001031/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="凤凰香港" group-title="IPV6·数字",凤凰香港「IPV6」
 http://[2409:8087:2001:20:2800:0:df6e:eb1d]/ott.mobaibox.com/PLTV/3/224/3221228530/1.m3u8
 #EXTINF:-1 tvg-name="凤凰中文" group-title="IPV6·数字",凤凰中文「IPV6」
@@ -164,11 +164,11 @@ http://[2409:8087:2001:20:2800:0:df6e:eb27]/ott.mobaibox.com/PLTV/3/224/32212285
 #EXTINF:-1 tvg-name="凤凰资讯" group-title="IPV6·数字",凤凰资讯「IPV6」
 http://[2409:8087:2001:20:2800:0:df6e:eb24]/ott.mobaibox.com/PLTV/3/224/3221228527/index.m3u8
 #EXTINF:-1 tvg-name="第一财经" group-title="IPV6·数字",第一财经「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001017/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001017/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="金鹰纪实" group-title="IPV6·数字",金鹰纪实「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001230/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001230/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="纪实人文" group-title="IPV6·数字",纪实人文「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001019/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001019/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="纪实科教" group-title="IPV6·数字",纪实科教「IPV6」
 http://[2409:8087:7000:20:1000::22]:6060/yinhe/2/ch00000090990000001329/index.m3u8?virtualDomain=yinhe.live_hls.zte.com
 #EXTINF:-1 tvg-name="求索动物" group-title="IPV6·数字",求索动物「IPV6」
@@ -180,9 +180,9 @@ http://[2409:8087:7001:20:1000::95]:6610/000000001000/6000000002000032344/index.
 #EXTINF:-1 tvg-name="求索纪录" group-title="IPV6·数字",求索纪录「IPV6」
 http://[2409:8087:7001:20:1000::95]:6610/000000001000/6000000002000032052/index.m3u8?channel-id=wasusyt&Contentid=6000000002000032052&livemode=1&stbId=3
 #EXTINF:-1 tvg-name="卡酷少儿" group-title="IPV6·数字",卡酷少儿「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001245/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001245/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="哈哈炫动" group-title="IPV6·数字",哈哈炫动「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001232/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001232/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="精彩综艺" group-title="IPV6·数字",精彩综艺「IPV6」
 http://[2409:8087:7000:20:1000::22]:6060/yinhe/2/ch00000090990000001273/index.m3u8?virtualDomain=yinhe.live_hls.zte.com
 #EXTINF:-1 tvg-name="null" group-title="IPV6·数字",精彩影视「IPV6」
@@ -194,27 +194,27 @@ http://[2409:8087:7000:20::4]/dbiptv.sn.chinamobile.com/PLTV/88888890/224/322122
 #EXTINF:-1 tvg-name="CHC家庭影院" group-title="IPV6·数字",CHC家庭影院「IPV6」
 http://[2409:8087:7000:20::4]/dbiptv.sn.chinamobile.com/PLTV/88888890/224/3221226462/index.m3u8
 #EXTINF:-1 tvg-name="生活时尚" group-title="IPV6·数字",SiTV五星体育「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001018/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001018/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="东方财经" group-title="IPV6·数字",SiTV东方财经「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001318/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001318/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="欢笑剧场" group-title="IPV6·数字",SiTV欢笑剧场「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001193/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001193/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="法治天地" group-title="IPV6·数字",SiTV法治天地「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001195/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001195/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="七彩戏剧" group-title="IPV6·数字",SiTV七彩戏剧「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001308/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001308/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="乐游" group-title="IPV6·数字",SiTV乐游「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001200/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001200/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="动漫秀场" group-title="IPV6·数字",SiTV动漫秀场「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001196/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001196/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="游戏风云" group-title="IPV6·数字",SiTV游戏风云「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001192/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001192/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="生活时尚" group-title="IPV6·数字",SiTV生活时尚「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001199/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001199/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="都市剧场" group-title="IPV6·数字",SiTV都市剧场「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001203/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001203/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="金色学堂" group-title="IPV6·数字",SiTV金色学堂「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001194/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001194/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="超级电影" group-title="IPV6·数字",NewTv超级电影「IPV6」
 http://[2409:8087:1a01:df::7005]/ottrrs.hl.chinamobile.com/PLTV/88888888/224/3221225717/index.m3u8
 #EXTINF:-1 tvg-name="超级电视剧" group-title="IPV6·数字",NewTv超级电视剧「IPV6」
@@ -332,25 +332,25 @@ http://[2409:8087:7001:20:1000::95]:6610/000000001000/6000000006000130630/index.
 #EXTINF:-1 tvg-name="null" group-title="IPV6·数字",iHOT爱院线「IPV6」
 http://[2409:8087:7001:20:1000::95]:6610/000000001000/6000000006000030630/index.m3u8?channel-id=wasusyt&Contentid=6000000006000030630&livemode=1&stbId=3
 #EXTINF:-1 tvg-name="快乐垂钓" group-title="IPV6·数字",快乐垂钓「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001235/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001235/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="茶频道" group-title="IPV6·数字",茶频道「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001234/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001234/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="中国交通" group-title="IPV6·数字",中国交通「IPV6」
 http://[2409:8087:5e01:34::20]:6610/ZTE_CMS/08984400000000060000000000000438/index.m3u8?IAS
 #EXTINF:-1 group-title="IPV6·数字",央广购物「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001420/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001420/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·数字",东方购物「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001039/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001039/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="上海东方影视" group-title="IPV6·地区",「上海」东方影视「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001016/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001016/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="上海都市" group-title="IPV6·地区",「上海」都市「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001015/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001015/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="上海教育电视台" group-title="IPV6·地区",「上海」教育电视台「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001268/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001268/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="上海外语频道" group-title="IPV6·地区",「上海」外语频道「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001128/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001128/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="上海新闻综合" group-title="IPV6·地区",「上海」新闻综合「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001014/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001014/index.m3u8?love=freedom
 #EXTINF:-1 tvg-name="null" group-title="IPV6·地区",「江苏」江苏交通广播「IPV6」
 http://[2409:8087:2001:20:2800:0:df6e:eb02]/wh7f454c46tw546624575_-1910844548/ott.mobaibox.com/PLTV/3/224/3221227937/index.m3u8
 #EXTINF:-1 tvg-name="null" group-title="IPV6·地区",「江苏」江苏健康广播「IPV6」
@@ -532,27 +532,27 @@ http://[2409:8087:7000:20::4]/dbiptv.sn.chinamobile.com/PLTV/88888888/224/322122
 #EXTINF:-1 group-title="IPV6·地区",「陕西」佛坪电视台「IPV6」
 http://[2409:8087:7002:20::3]/dbiptv.sn.chinamobile.com/PLTV/88888888/224/3221226454/index.m3u8
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-1「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001148/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001148/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-2「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001149/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001149/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-3「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001150/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001150/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-4「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001151/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001151/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-5「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001152/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001152/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-6「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001153/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001153/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-7「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001154/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001154/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-8「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001359/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001359/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-9「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001378/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001378/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-10「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001388/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001388/index.m3u8?love=freedom
 #EXTINF:-1 group-title="IPV6·BesTV",BesTV-11「IPV6」
-http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001398/index.m3u8?
+http://[2409:8087:1e03:21::42]:6610/cms001/ch00000090990000001398/index.m3u8?love=freedom
 #EXTINF:-1 tvg-logo="https://i.postimg.cc/L5frXm2p/mg.jpg" group-title="IPV6·咪咕",咪咕直播4K-1「IPV6」
 http://[2409:8087:1a01:df::4001]/PLTV/88888888/224/3221225655/index.m3u8
 #EXTINF:-1 tvg-logo="https://i.postimg.cc/L5frXm2p/mg.jpg" group-title="IPV6·咪咕",咪咕直播4K-2「IPV6」


### PR DESCRIPTION
某些带有`?`号的地址无法被tivimate正确处理,统一替换为`?love=freedom`,使其符合标准URL传参,得以被tivimate正确对待 
#28  